### PR TITLE
Teams deletion

### DIFF
--- a/src/api/teamApi.ts
+++ b/src/api/teamApi.ts
@@ -1,7 +1,7 @@
 import type { AuthStrategy } from "@/lib/authProvider";
 import { Team } from "@/types/team";
 import { User } from "@/types/user";
-import { fetchHalCollection, fetchHalResource } from "./halClient";
+import { deleteHal, fetchHalCollection, fetchHalResource } from "./halClient";
 
 function getSafeEncodedId(id: string): string {
     try {
@@ -31,5 +31,10 @@ export class TeamsService {
     async getTeamMembers(id: string): Promise<User[]> {
         const teamId = getSafeEncodedId(id);
         return fetchHalCollection<User>(`/teams/${teamId}/members`, this.authStrategy, 'teamMembers');
+    }
+
+    async deleteTeam(id: string): Promise<void> {
+        const teamId = getSafeEncodedId(id);
+        await deleteHal(`/teams/${teamId}`, this.authStrategy);
     }
 }

--- a/src/app/teams/[id]/delete-team-dialog.tsx
+++ b/src/app/teams/[id]/delete-team-dialog.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { TeamsService } from "@/api/teamApi";
+import { Button } from "@/app/components/button";
+import ErrorAlert from "@/app/components/error-alert";
+import { clientAuthProvider } from "@/lib/authProvider";
+import { parseErrorMessage } from "@/types/errors";
+
+interface DeleteTeamDialogProps {
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly onCancel: () => void;
+}
+
+export default function DeleteTeamDialog({
+  teamId,
+  teamName,
+  onCancel,
+}: DeleteTeamDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const service = new TeamsService(clientAuthProvider);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    dialog.showModal();
+
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    function handleCancel(event: Event) {
+      event.preventDefault();
+      if (!isDeleting) onCancel();
+    }
+
+    dialog.addEventListener("cancel", handleCancel);
+    return () => dialog.removeEventListener("cancel", handleCancel);
+  }, [isDeleting, onCancel]);
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    setErrorMessage(null);
+
+    try {
+      await service.deleteTeam(teamId);
+      router.push("/teams");
+      router.refresh();
+    } catch (error) {
+      setErrorMessage(parseErrorMessage(error));
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby={titleId}
+      aria-busy={isDeleting}
+      className="m-auto w-full max-w-md border border-border bg-card px-6 py-6 shadow-lg backdrop:bg-black/50 sm:px-8 sm:py-8"
+    >
+      <h2
+        id={titleId}
+        className="text-lg font-semibold tracking-[-0.03em] text-foreground"
+      >
+        Delete team
+      </h2>
+
+      <p className="mt-3 text-sm leading-6 text-muted-foreground">
+        Are you sure you want to delete{" "}
+        <span className="font-semibold text-foreground">{teamName}</span>? This
+        action cannot be undone.
+      </p>
+
+      {errorMessage && (
+        <div className="mt-4">
+          <ErrorAlert message={errorMessage} />
+        </div>
+      )}
+
+      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <Button
+          autoFocus
+          type="button"
+          variant="outline"
+          disabled={isDeleting}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={isDeleting}
+          onClick={handleDelete}
+        >
+          {isDeleting ? "Deleting..." : "Delete team"}
+        </Button>
+      </div>
+    </dialog>
+  );
+}

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -1,10 +1,13 @@
 import { TeamsService } from "@/api/teamApi";
+import { UsersService } from "@/api/userApi";
 import ErrorAlert from "@/app/components/error-alert";
 import EmptyState from "@/app/components/empty-state";
 import { serverAuthProvider } from "@/lib/authProvider";
+import { isAdmin } from "@/lib/authz";
 import { Team } from "@/types/team";
 import { User } from "@/types/user";
 import { parseErrorMessage, NotFoundError } from "@/types/errors";
+import TeamDeleteSection from "./team-delete-section";
 
 interface TeamDetailPageProps {
     readonly params: Promise<{ id: string }>;
@@ -35,8 +38,15 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
     let team: Team | null = null;
     let coaches: User[] = [];
     let members: User[] = [];
+    let currentUser: User | null = null;
     let error: string | null = null;
     let membersError: string | null = null;
+
+    try {
+        currentUser = await new UsersService(serverAuthProvider).getCurrentUser();
+    } catch (e) {
+        console.error("Failed to fetch current user:", e);
+    }
 
     try {
         team = await service.getTeamById(id);
@@ -70,12 +80,22 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
                     <h1 className="mb-2 text-2xl font-semibold">{getTeamTitle(team, id)}</h1>
                     
                     {!error && team && (
-                         <div className="mb-6 space-y-1 text-sm text-zinc-600">
-                             {team.city && <p><strong>City:</strong> {team.city}</p>}
-                             {team.category && <p><strong>Category:</strong> {team.category}</p>}
-                             {team.educationalCenter && <p><strong>Educational Center:</strong> {team.educationalCenter}</p>}
-                             <p><strong>Coach:</strong> {coachName}</p>
-                         </div>
+                        <>
+                            <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+                                <div className="space-y-1 text-sm text-zinc-600">
+                                    {team.city && <p><strong>City:</strong> {team.city}</p>}
+                                    {team.category && <p><strong>Category:</strong> {team.category}</p>}
+                                    {team.educationalCenter && <p><strong>Educational Center:</strong> {team.educationalCenter}</p>}
+                                    <p><strong>Coach:</strong> {coachName}</p>
+                                </div>
+                                {isAdmin(currentUser) && (
+                                    <TeamDeleteSection
+                                        teamId={id}
+                                        teamName={getTeamTitle(team, id)}
+                                    />
+                                )}
+                            </div>
+                        </>
                     )}
 
                     {error && (

--- a/src/app/teams/[id]/team-delete-section.tsx
+++ b/src/app/teams/[id]/team-delete-section.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/app/components/button";
+import DeleteTeamDialog from "./delete-team-dialog";
+
+interface TeamDeleteSectionProps {
+  readonly teamId: string;
+  readonly teamName: string;
+}
+
+export default function TeamDeleteSection({
+  teamId,
+  teamName,
+}: TeamDeleteSectionProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        onClick={() => setIsDialogOpen(true)}
+      >
+        Delete team
+      </Button>
+
+      {isDialogOpen && (
+        <DeleteTeamDialog
+          teamId={teamId}
+          teamName={teamName}
+          onCancel={() => setIsDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
This PR adds administrator-only team deletion from the team details page. When an admin visits /teams/[id], they now see a Delete team action that opens a confirmation dialog, calls the backend DELETE /teams/{id} endpoint through the shared TeamsService, and then redirects back to /teams. Because the team list page already fetches data dynamically, the deleted team no longer appears after the redirect. The change also keeps role-based access aligned with the rest of the app by checking the current user’s admin authority before rendering the delete control.