### PR TITLE
Button Teams deletion

### DIFF
--- a/src/api/teamApi.ts
+++ b/src/api/teamApi.ts
@@ -5,6 +5,7 @@ import { deleteHal, fetchHalCollection, fetchHalResource } from "./halClient";
 
 function getSafeEncodedId(id: string): string {
     try {
+        // HAL links may already contain encoded ids, so normalize before reusing them.
         return encodeURIComponent(decodeURIComponent(id));
     } catch {
         return encodeURIComponent(id);

--- a/src/api/teamApi.ts
+++ b/src/api/teamApi.ts
@@ -1,7 +1,7 @@
 import type { AuthStrategy } from "@/lib/authProvider";
 import { Team } from "@/types/team";
 import { User } from "@/types/user";
-import { fetchHalCollection, fetchHalResource } from "./halClient";
+import { deleteHal, fetchHalCollection, fetchHalResource } from "./halClient";
 
 function getSafeEncodedId(id: string): string {
     try {
@@ -31,5 +31,10 @@ export class TeamsService {
     async getTeamMembers(id: string): Promise<User[]> {
         const teamId = getSafeEncodedId(id);
         return fetchHalCollection<User>(`/teams/${teamId}/members`, this.authStrategy, 'teamMembers');
+    }
+
+    async deleteTeam(id: string): Promise<void> {
+        const teamId = getSafeEncodedId(id);
+        await deleteHal(`/teams/${teamId}`, this.authStrategy);
     }
 }

--- a/src/app/administrators/delete-administrator-dialog.tsx
+++ b/src/app/administrators/delete-administrator-dialog.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
-import { Button } from "@/app/components/button";
-import ErrorAlert from "@/app/components/error-alert";
 import { UsersService } from "@/api/userApi";
+import ConfirmDestructiveDialog from "@/app/components/confirm-destructive-dialog";
 import { clientAuthProvider } from "@/lib/authProvider";
 import { UserEntity } from "@/types/user";
-import { parseErrorMessage } from "@/types/errors";
 
 interface DeleteAdministratorDialogProps {
   readonly administrator: UserEntity;
@@ -19,107 +16,40 @@ export default function DeleteAdministratorDialog({
   onSuccess,
   onCancel,
 }: DeleteAdministratorDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const titleId = useId();
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const service = new UsersService(clientAuthProvider);
 
   // Open as a native modal — built-in focus trap, backdrop and accessibility
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    dialog.showModal();
-
-    return () => {
-      if (dialog.open) dialog.close();
-    };
-  }, []);
 
   // Intercept the native Escape cancel event to block closing while a delete is in progress
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
 
-    function handleCancel(event: Event) {
-      event.preventDefault();
-      if (!isDeleting) onCancel();
-    }
-
-    dialog.addEventListener("cancel", handleCancel);
-    return () => dialog.removeEventListener("cancel", handleCancel);
-  }, [isDeleting, onCancel]);
-
+  // The shared dialog already handles pending and error states for us.
   async function handleDelete() {
-    setIsDeleting(true);
-    setErrorMessage(null);
-
-    try {
-      await service.deleteUser(administrator.username);
-      onSuccess();
-    } catch (e) {
-      setErrorMessage(parseErrorMessage(e));
-      setIsDeleting(false);
-    }
+    await service.deleteUser(administrator.username);
+    onSuccess();
   }
 
   return (
-    <dialog
-      ref={dialogRef}
-      aria-labelledby={titleId}
-      aria-busy={isDeleting}
-      className="m-auto w-full max-w-md border border-border bg-card px-6 py-6 shadow-lg backdrop:bg-black/50 sm:px-8 sm:py-8"
-    >
-      <h2
-        id={titleId}
-        className="text-lg font-semibold tracking-[-0.03em] text-foreground"
-      >
-        Delete administrator
-      </h2>
-
-      <p className="mt-3 text-sm leading-6 text-muted-foreground">
-        Are you sure you want to delete{" "}
-        <span className="font-semibold text-foreground">
-          {administrator.username}
-        </span>
-        {administrator.email && (
-          <>
-            {" "}
-            (<span className="text-foreground">{administrator.email}</span>)
-          </>
-        )}
-        ? This action cannot be undone.
-      </p>
-
-      {errorMessage && (
-        <div className="mt-4">
-          <ErrorAlert message={errorMessage} />
-        </div>
-      )}
-
-      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-        {/* autoFocus ensures initial focus lands on the safe action (Cancel) when the dialog opens */}
-        <Button
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
-          type="button"
-          variant="outline"
-          disabled={isDeleting}
-          onClick={onCancel}
-        >
-          Cancel
-        </Button>
-
-        <Button
-          type="button"
-          variant="destructive"
-          disabled={isDeleting}
-          onClick={handleDelete}
-        >
-          {isDeleting ? "Deleting…" : "Delete administrator"}
-        </Button>
-      </div>
-    </dialog>
+    <ConfirmDestructiveDialog
+      title="Delete administrator"
+      description={
+        <p>
+          Are you sure you want to delete{" "}
+          <span className="font-semibold text-foreground">
+            {administrator.username}
+          </span>
+          {administrator.email && (
+            <>
+              {" "}
+              (<span className="text-foreground">{administrator.email}</span>)
+            </>
+          )}
+          ? This action cannot be undone.
+        </p>
+      }
+      confirmLabel="Delete administrator"
+      pendingLabel="Deleting..."
+      onConfirm={handleDelete}
+      onCancel={onCancel}
+    />
   );
 }

--- a/src/app/components/confirm-destructive-dialog.tsx
+++ b/src/app/components/confirm-destructive-dialog.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { ReactNode, useEffect, useId, useRef, useState } from "react";
+import { Button } from "@/app/components/button";
+import ErrorAlert from "@/app/components/error-alert";
+import { parseErrorMessage } from "@/types/errors";
+
+interface ConfirmDestructiveDialogProps {
+  readonly title: string;
+  readonly description: ReactNode;
+  readonly confirmLabel: string;
+  readonly pendingLabel: string;
+  readonly onConfirm: () => Promise<void>;
+  readonly onCancel: () => void;
+}
+
+export default function ConfirmDestructiveDialog({
+  title,
+  description,
+  confirmLabel,
+  pendingLabel,
+  onConfirm,
+  onCancel,
+}: ConfirmDestructiveDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+  const [isPending, setIsPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    // Native dialogs give us focus trapping and Escape/backdrop behavior for free.
+    dialog.showModal();
+
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    function handleCancel(event: Event) {
+      // Block dismissal while the destructive request is still running.
+      event.preventDefault();
+      if (!isPending) onCancel();
+    }
+
+    dialog.addEventListener("cancel", handleCancel);
+    return () => dialog.removeEventListener("cancel", handleCancel);
+  }, [isPending, onCancel]);
+
+  async function handleConfirm() {
+    setIsPending(true);
+    setErrorMessage(null);
+
+    try {
+      // Callers only provide the mutation; this wrapper owns shared modal UX.
+      await onConfirm();
+    } catch (error) {
+      setErrorMessage(parseErrorMessage(error));
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby={titleId}
+      aria-busy={isPending}
+      className="m-auto w-full max-w-md border border-border bg-card px-6 py-6 shadow-lg backdrop:bg-black/50 sm:px-8 sm:py-8"
+    >
+      <h2
+        id={titleId}
+        className="text-lg font-semibold tracking-[-0.03em] text-foreground"
+      >
+        {title}
+      </h2>
+
+      <div className="mt-3 text-sm leading-6 text-muted-foreground">
+        {description}
+      </div>
+
+      {errorMessage && (
+        <div className="mt-4">
+          <ErrorAlert message={errorMessage} />
+        </div>
+      )}
+
+      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <Button
+          autoFocus
+          type="button"
+          variant="outline"
+          disabled={isPending}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={isPending}
+          onClick={handleConfirm}
+        >
+          {isPending ? pendingLabel : confirmLabel}
+        </Button>
+      </div>
+    </dialog>
+  );
+}

--- a/src/app/teams/[id]/delete-team-dialog.tsx
+++ b/src/app/teams/[id]/delete-team-dialog.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { TeamsService } from "@/api/teamApi";
-import { Button } from "@/app/components/button";
-import ErrorAlert from "@/app/components/error-alert";
+import ConfirmDestructiveDialog from "@/app/components/confirm-destructive-dialog";
 import { clientAuthProvider } from "@/lib/authProvider";
-import { parseErrorMessage } from "@/types/errors";
 
 interface DeleteTeamDialogProps {
   readonly teamId: string;
@@ -19,97 +16,30 @@ export default function DeleteTeamDialog({
   teamName,
   onCancel,
 }: DeleteTeamDialogProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const titleId = useId();
   const router = useRouter();
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const service = new TeamsService(clientAuthProvider);
 
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    dialog.showModal();
-
-    return () => {
-      if (dialog.open) dialog.close();
-    };
-  }, []);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    function handleCancel(event: Event) {
-      event.preventDefault();
-      if (!isDeleting) onCancel();
-    }
-
-    dialog.addEventListener("cancel", handleCancel);
-    return () => dialog.removeEventListener("cancel", handleCancel);
-  }, [isDeleting, onCancel]);
-
   async function handleDelete() {
-    setIsDeleting(true);
-    setErrorMessage(null);
-
-    try {
-      await service.deleteTeam(teamId);
-      router.push("/teams");
-      router.refresh();
-    } catch (error) {
-      setErrorMessage(parseErrorMessage(error));
-      setIsDeleting(false);
-    }
+    await service.deleteTeam(teamId);
+    // Refresh the destination page so the list reflects the deletion immediately.
+    router.push("/teams");
+    router.refresh();
   }
 
   return (
-    <dialog
-      ref={dialogRef}
-      aria-labelledby={titleId}
-      aria-busy={isDeleting}
-      className="m-auto w-full max-w-md border border-border bg-card px-6 py-6 shadow-lg backdrop:bg-black/50 sm:px-8 sm:py-8"
-    >
-      <h2
-        id={titleId}
-        className="text-lg font-semibold tracking-[-0.03em] text-foreground"
-      >
-        Delete team
-      </h2>
-
-      <p className="mt-3 text-sm leading-6 text-muted-foreground">
-        Are you sure you want to delete{" "}
-        <span className="font-semibold text-foreground">{teamName}</span>? This
-        action cannot be undone.
-      </p>
-
-      {errorMessage && (
-        <div className="mt-4">
-          <ErrorAlert message={errorMessage} />
-        </div>
-      )}
-
-      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-        <Button
-          autoFocus
-          type="button"
-          variant="outline"
-          disabled={isDeleting}
-          onClick={onCancel}
-        >
-          Cancel
-        </Button>
-
-        <Button
-          type="button"
-          variant="destructive"
-          disabled={isDeleting}
-          onClick={handleDelete}
-        >
-          {isDeleting ? "Deleting..." : "Delete team"}
-        </Button>
-      </div>
-    </dialog>
+    <ConfirmDestructiveDialog
+      title="Delete team"
+      description={
+        <p>
+          Are you sure you want to delete{" "}
+          <span className="font-semibold text-foreground">{teamName}</span>?
+          This action cannot be undone.
+        </p>
+      }
+      confirmLabel="Delete team"
+      pendingLabel="Deleting..."
+      onConfirm={handleDelete}
+      onCancel={onCancel}
+    />
   );
 }

--- a/src/app/teams/[id]/delete-team-dialog.tsx
+++ b/src/app/teams/[id]/delete-team-dialog.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { TeamsService } from "@/api/teamApi";
+import { Button } from "@/app/components/button";
+import ErrorAlert from "@/app/components/error-alert";
+import { clientAuthProvider } from "@/lib/authProvider";
+import { parseErrorMessage } from "@/types/errors";
+
+interface DeleteTeamDialogProps {
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly onCancel: () => void;
+}
+
+export default function DeleteTeamDialog({
+  teamId,
+  teamName,
+  onCancel,
+}: DeleteTeamDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const service = new TeamsService(clientAuthProvider);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    dialog.showModal();
+
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    function handleCancel(event: Event) {
+      event.preventDefault();
+      if (!isDeleting) onCancel();
+    }
+
+    dialog.addEventListener("cancel", handleCancel);
+    return () => dialog.removeEventListener("cancel", handleCancel);
+  }, [isDeleting, onCancel]);
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    setErrorMessage(null);
+
+    try {
+      await service.deleteTeam(teamId);
+      router.push("/teams");
+      router.refresh();
+    } catch (error) {
+      setErrorMessage(parseErrorMessage(error));
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby={titleId}
+      aria-busy={isDeleting}
+      className="m-auto w-full max-w-md border border-border bg-card px-6 py-6 shadow-lg backdrop:bg-black/50 sm:px-8 sm:py-8"
+    >
+      <h2
+        id={titleId}
+        className="text-lg font-semibold tracking-[-0.03em] text-foreground"
+      >
+        Delete team
+      </h2>
+
+      <p className="mt-3 text-sm leading-6 text-muted-foreground">
+        Are you sure you want to delete{" "}
+        <span className="font-semibold text-foreground">{teamName}</span>? This
+        action cannot be undone.
+      </p>
+
+      {errorMessage && (
+        <div className="mt-4">
+          <ErrorAlert message={errorMessage} />
+        </div>
+      )}
+
+      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <Button
+          autoFocus
+          type="button"
+          variant="outline"
+          disabled={isDeleting}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={isDeleting}
+          onClick={handleDelete}
+        >
+          {isDeleting ? "Deleting..." : "Delete team"}
+        </Button>
+      </div>
+    </dialog>
+  );
+}

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -1,10 +1,13 @@
 import { TeamsService } from "@/api/teamApi";
+import { UsersService } from "@/api/userApi";
 import ErrorAlert from "@/app/components/error-alert";
 import EmptyState from "@/app/components/empty-state";
 import { serverAuthProvider } from "@/lib/authProvider";
+import { isAdmin } from "@/lib/authz";
 import { Team } from "@/types/team";
 import { User } from "@/types/user";
 import { parseErrorMessage, NotFoundError } from "@/types/errors";
+import TeamDeleteSection from "./team-delete-section";
 
 interface TeamDetailPageProps {
     readonly params: Promise<{ id: string }>;
@@ -35,8 +38,15 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
     let team: Team | null = null;
     let coaches: User[] = [];
     let members: User[] = [];
+    let currentUser: User | null = null;
     let error: string | null = null;
     let membersError: string | null = null;
+
+    try {
+        currentUser = await new UsersService(serverAuthProvider).getCurrentUser();
+    } catch (e) {
+        console.error("Failed to fetch current user:", e);
+    }
 
     try {
         team = await service.getTeamById(id);
@@ -70,12 +80,22 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
                     <h1 className="mb-2 text-2xl font-semibold">{getTeamTitle(team, id)}</h1>
                     
                     {!error && team && (
-                         <div className="mb-6 space-y-1 text-sm text-zinc-600">
-                             {team.city && <p><strong>City:</strong> {team.city}</p>}
-                             {team.category && <p><strong>Category:</strong> {team.category}</p>}
-                             {team.educationalCenter && <p><strong>Educational Center:</strong> {team.educationalCenter}</p>}
-                             <p><strong>Coach:</strong> {coachName}</p>
-                         </div>
+                        <>
+                            <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+                                <div className="space-y-1 text-sm text-zinc-600">
+                                    {team.city && <p><strong>City:</strong> {team.city}</p>}
+                                    {team.category && <p><strong>Category:</strong> {team.category}</p>}
+                                    {team.educationalCenter && <p><strong>Educational Center:</strong> {team.educationalCenter}</p>}
+                                    <p><strong>Coach:</strong> {coachName}</p>
+                                </div>
+                                {isAdmin(currentUser) && (
+                                    <TeamDeleteSection
+                                        teamId={id}
+                                        teamName={getTeamTitle(team, id)}
+                                    />
+                                )}
+                            </div>
+                        </>
                     )}
 
                     {error && (

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -43,6 +43,7 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
     let membersError: string | null = null;
 
     try {
+        // Enforce the admin-only delete action from the server-rendered page as well.
         currentUser = await new UsersService(serverAuthProvider).getCurrentUser();
     } catch (e) {
         console.error("Failed to fetch current user:", e);
@@ -59,6 +60,7 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
 
     if (team && !error) {
         try {
+            // Fetch related collections together once the team itself has loaded.
             [coaches, members] = await Promise.all([
                 service.getTeamCoach(id),
                 service.getTeamMembers(id)

--- a/src/app/teams/[id]/team-delete-section.tsx
+++ b/src/app/teams/[id]/team-delete-section.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/app/components/button";
+import DeleteTeamDialog from "./delete-team-dialog";
+
+interface TeamDeleteSectionProps {
+  readonly teamId: string;
+  readonly teamName: string;
+}
+
+export default function TeamDeleteSection({
+  teamId,
+  teamName,
+}: TeamDeleteSectionProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        onClick={() => setIsDialogOpen(true)}
+      >
+        Delete team
+      </Button>
+
+      {isDialogOpen && (
+        <DeleteTeamDialog
+          teamId={teamId}
+          teamName={teamName}
+          onCancel={() => setIsDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/teams/[id]/team-delete-section.tsx
+++ b/src/app/teams/[id]/team-delete-section.tsx
@@ -13,6 +13,7 @@ export default function TeamDeleteSection({
   teamId,
   teamName,
 }: TeamDeleteSectionProps) {
+  // Keep the dialog toggle local so the server page only passes stable team data.
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (


### PR DESCRIPTION
This PR adds administrator-only team deletion from the team details page. When an admin visits /teams/[id], they now see a Delete team action that opens a confirmation dialog, calls the backend DELETE /teams/{id} endpoint through the shared TeamsService, and then redirects back to /teams. Because the team list page already fetches data dynamically, the deleted team no longer appears after the redirect. The change also keeps role-based access aligned with the rest of the app by checking the current user’s admin authority before rendering the delete control.

closes #61