### PR TITLE
Scientific project in teams

### DIFF
--- a/src/api/scientificProjectApi.ts
+++ b/src/api/scientificProjectApi.ts
@@ -1,6 +1,6 @@
 import type { AuthStrategy } from "@/lib/authProvider";
 import { ScientificProject } from "@/types/scientificProject";
-import { getHal, mergeHal, mergeHalArray, postHal, fetchHalResource } from "./halClient";
+import { fetchHalCollection, fetchHalResource, getHal, mergeHal, mergeHalArray, postHal } from "./halClient";
 
 export class ScientificProjectsService {
     constructor(private readonly authStrategy: AuthStrategy) { }
@@ -9,6 +9,15 @@ export class ScientificProjectsService {
         const resource = await getHal('/scientificProjects', this.authStrategy);
         const embedded = resource.embeddedArray('scientificProjects') || [];
         return mergeHalArray<ScientificProject>(embedded);
+    }
+
+    async getScientificProjectsByTeamName(teamName: string): Promise<ScientificProject[]> {
+        const encodedTeamName = encodeURIComponent(teamName);
+        return fetchHalCollection<ScientificProject>(
+            `/scientificProjects/search/findByTeamName?teamName=${encodedTeamName}`,
+            this.authStrategy,
+            "scientificProjects"
+        );
     }
 
     async getScientificProjectById(id: string): Promise<ScientificProject> {

--- a/src/app/components/scientific-project-card.tsx
+++ b/src/app/components/scientific-project-card.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import { getEncodedResourceId } from "@/lib/halRoute";
+import { ScientificProject } from "@/types/scientificProject";
+
+type ScientificProjectCardVariant = "grid" | "stacked";
+
+interface ScientificProjectCardProps {
+    readonly project: ScientificProject;
+    readonly index: number;
+    readonly variant?: ScientificProjectCardVariant;
+}
+
+function getScientificProjectLabel(index: number): string {
+    return `Scientific Project #${index + 1}`;
+}
+
+function getScientificProjectTitle(project: ScientificProject, index: number): string {
+    return project.comments ? project.comments : `Project ${index + 1}`;
+}
+
+function getScientificProjectHref(project: ScientificProject): string | null {
+    const resourceUri = project.uri ?? project.link("self")?.href;
+    const projectId = getEncodedResourceId(resourceUri);
+
+    return projectId ? `/scientific-projects/${projectId}` : null;
+}
+
+export function ScientificProjectCard({
+    project,
+    index,
+    variant = "grid",
+}: Readonly<ScientificProjectCardProps>) {
+    if (variant === "stacked") {
+        return (
+            <div className="rounded-lg border bg-white p-4 transition-colors hover:bg-zinc-50 dark:bg-zinc-950 dark:hover:bg-zinc-900">
+                <div className="list-kicker">{getScientificProjectLabel(index)}</div>
+                <div className="list-title mt-1">{getScientificProjectTitle(project, index)}</div>
+                {project.score !== undefined && project.score !== null && (
+                    <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                        Score: {project.score} pts
+                    </p>
+                )}
+            </div>
+        );
+    }
+
+    return (
+        <div className="list-card block h-full pl-7 transition-colors hover:bg-secondary/30">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0 space-y-2">
+                    <div className="list-kicker">{getScientificProjectLabel(index)}</div>
+                    <div className="list-title">{getScientificProjectTitle(project, index)}</div>
+                    {project.score !== undefined && project.score !== null && (
+                        <div className="list-support">Score: {project.score}</div>
+                    )}
+                </div>
+                {project.score !== undefined && project.score !== null && (
+                    <div className="status-badge">{project.score} pts</div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export function ScientificProjectCardLink({
+    project,
+    index,
+    variant = "grid",
+}: Readonly<ScientificProjectCardProps>) {
+    const href = getScientificProjectHref(project);
+    const card = <ScientificProjectCard project={project} index={index} variant={variant} />;
+
+    if (!href) {
+        return card;
+    }
+
+    return (
+        <Link
+            href={href}
+            className={variant === "grid" ? "block h-full" : "block rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"}
+        >
+            {card}
+        </Link>
+    );
+}

--- a/src/app/scientific-projects/page.tsx
+++ b/src/app/scientific-projects/page.tsx
@@ -2,33 +2,12 @@ import { ScientificProjectsService } from "@/api/scientificProjectApi";
 import PageShell from "@/app/components/page-shell";
 import ErrorAlert from "@/app/components/error-alert";
 import EmptyState from "@/app/components/empty-state";
+import { ScientificProjectCardLink } from "@/app/components/scientific-project-card";
 import { serverAuthProvider } from "@/lib/authProvider";
-import { getEncodedResourceId } from "@/lib/halRoute";
 import { ScientificProject } from "@/types/scientificProject";
 import Link from "next/link";
 import { buttonVariants } from "@/app/components/button";
 import { parseErrorMessage } from "@/types/errors";
-
-function ScientificProjectCard({ project, index }: Readonly<{ project: ScientificProject; index: number }>) {
-    return (
-        <div className="list-card block h-full pl-7 transition-colors hover:bg-secondary/30">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-                <div className="min-w-0 space-y-2">
-                    <div className="list-kicker">Scientific Project #{index + 1}</div>
-                    <div className="list-title">
-                        {project.comments ? project.comments : `Project ${index + 1}`}
-                    </div>
-                    {project.score !== undefined && project.score !== null && (
-                        <div className="list-support">Score: {project.score}</div>
-                    )}
-                </div>
-                {project.score !== undefined && project.score !== null && (
-                    <div className="status-badge">{project.score} pts</div>
-                )}
-            </div>
-        </div>
-    );
-}
 
 export default async function ScientificProjectsPage() {
     let projects: ScientificProject[] = [];
@@ -75,19 +54,11 @@ export default async function ScientificProjectsPage() {
 
                 {!error && projects.length > 0 && (
                     <ul className="list-grid">
-                        {projects.map((project, index) => {
-                            const projectId = getEncodedResourceId(project.uri);
-                            const card = <ScientificProjectCard project={project} index={index} />;
-                            return (
-                                <li key={project.uri ?? index}>
-                                    {projectId ? (
-                                        <Link href={`/scientific-projects/${projectId}`} className="block h-full">
-                                            {card}
-                                        </Link>
-                                    ) : card}
-                                </li>
-                            );
-                        })}
+                        {projects.map((project, index) => (
+                            <li key={project.uri ?? project.link("self")?.href ?? index}>
+                                <ScientificProjectCardLink project={project} index={index} />
+                            </li>
+                        ))}
                     </ul>
                 )}
             </div>

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -1,8 +1,11 @@
 import { TeamsService } from "@/api/teamApi";
+import { ScientificProjectsService } from "@/api/scientificProjectApi";
 import { UsersService } from "@/api/userApi";
 import ErrorAlert from "@/app/components/error-alert";
 import EmptyState from "@/app/components/empty-state";
+import { ScientificProjectCardLink } from "@/app/components/scientific-project-card";
 import { serverAuthProvider } from "@/lib/authProvider";
+import { ScientificProject } from "@/types/scientificProject";
 import { Team } from "@/types/team";
 import { User } from "@/types/user";
 import { parseErrorMessage, NotFoundError } from "@/types/errors";
@@ -27,6 +30,14 @@ interface HalMemberResponse {
     _embedded?: {
         teamMembers: RawMember[];
     };
+}
+
+function getTeamDisplayName(team: Team | null): string | null {
+    if (!team) {
+        return null;
+    }
+
+    return team.name ?? team.id ?? null;
 }
 
 function extractTeamMembers(data: unknown): User[] {
@@ -56,14 +67,17 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
     const { id } = await props.params;
 
     const service = new TeamsService(serverAuthProvider);
+    const scientificProjectsService = new ScientificProjectsService(serverAuthProvider);
     const userService = new UsersService(serverAuthProvider);
 
     let currentUser: User | null = null;
     let team: Team | null = null;
     let coaches: User[] = [];
     let members: User[] = [];
+    let scientificProjects: ScientificProject[] = [];
     let error: string | null = null;
     let membersError: string | null = null;
+    let scientificProjectsError: string | null = null;
 
     try {
         currentUser = await userService.getCurrentUser().catch(() => null);
@@ -75,18 +89,30 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
         error = parseErrorMessage(e);
     }
 
+    const teamDisplayName = getTeamDisplayName(team);
+
     if (team && !error) {
-        try {
-            const [coachesData, membersData] = await Promise.all([
-                service.getTeamCoach(id),
-                service.getTeamMembers(id)
-            ]);
-            
+        const [membersResult, scientificProjectsResult] = await Promise.allSettled([
+            Promise.all([service.getTeamCoach(id), service.getTeamMembers(id)]),
+            teamDisplayName
+                ? scientificProjectsService.getScientificProjectsByTeamName(teamDisplayName)
+                : Promise.resolve([] as ScientificProject[])
+        ]);
+
+        if (membersResult.status === "fulfilled") {
+            const [coachesData, membersData] = membersResult.value;
             coaches = coachesData ?? [];
             members = extractTeamMembers(membersData);
-        } catch (e) {
-            console.error("Error loading members:", e);
-            membersError = parseErrorMessage(e);
+        } else {
+            console.error("Error loading members:", membersResult.reason);
+            membersError = parseErrorMessage(membersResult.reason);
+        }
+
+        if (scientificProjectsResult.status === "fulfilled") {
+            scientificProjects = scientificProjectsResult.value;
+        } else {
+            console.error("Error loading scientific projects:", scientificProjectsResult.reason);
+            scientificProjectsError = parseErrorMessage(scientificProjectsResult.reason);
         }
     }
 
@@ -109,12 +135,40 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
         <div className="flex min-h-screen items-center justify-center bg-zinc-50">
             <div className="w-full max-w-3xl px-4 py-10">
                 <div className="w-full rounded-lg border bg-white p-6 shadow-sm dark:bg-black">
-                    <h1 className="mb-2 text-2xl font-semibold">{team.name}</h1>
+                    <h1 className="mb-2 text-2xl font-semibold">{teamDisplayName ?? "Unnamed team"}</h1>
 
                     <div className="mb-6 space-y-1 text-sm text-zinc-600 dark:text-zinc-400">
                         {team.city && <p><strong>City:</strong> {team.city}</p>}
                         <p><strong>Coach:</strong> {coachName}</p>
                     </div>
+
+                    <section aria-labelledby="team-projects-heading">
+                        <h2 id="team-projects-heading" className="mt-8 mb-4 text-xl font-semibold">
+                            Scientific Projects
+                        </h2>
+
+                        {scientificProjectsError && (
+                            <ErrorAlert message={`Could not load scientific projects. ${scientificProjectsError}`} />
+                        )}
+
+                        {!scientificProjectsError && scientificProjects.length === 0 && (
+                            <EmptyState
+                                title="No scientific projects yet"
+                                description="This team has not submitted any scientific projects."
+                                className="py-8"
+                            />
+                        )}
+
+                        {!scientificProjectsError && scientificProjects.length > 0 && (
+                            <ul className="space-y-3">
+                                {scientificProjects.map((project, index) => (
+                                    <li key={project.uri ?? project.link("self")?.href ?? index}>
+                                        <ScientificProjectCardLink project={project} index={index} variant="stacked" />
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </section>
 
                     <h2 className="mt-8 mb-4 text-xl font-semibold">Team Members</h2>
 


### PR DESCRIPTION
This PR adds a new Scientific Projects section to the team detail page at /teams/[id], allowing users to see all projects submitted by a team and navigate directly to each /scientific-projects/[id] detail page. It includes the required empty state when a team has no projects and shows a section-level error message if the fetch fails without affecting the rest of the page. As part of the implementation, the scientific project card UI was refactored into a shared component to avoid duplication, and a backend compatibility issue was fixed by resolving the team display name from team.name ?? team.id, ensuring teams such as Test Team Alpha correctly load their associated projects.

Closes #94 