### PR TITLE
feat: add delete match button on match detail page for administrators

### DIFF
--- a/src/api/matchesApi.ts
+++ b/src/api/matchesApi.ts
@@ -4,7 +4,7 @@ import { Match } from "@/types/match";
 import { Referee } from "@/types/referee";
 import { Round } from "@/types/round";
 import { Team } from "@/types/team";
-import { createHalResource, fetchHalCollection, fetchHalResource } from "./halClient";
+import { createHalResource, deleteHal, fetchHalCollection, fetchHalResource } from "./halClient";
 
 export type CreateMatchPayload = {
     startTime: string;
@@ -71,5 +71,10 @@ export class MatchesService {
 
     async createMatch(data: CreateMatchPayload): Promise<Match> {
         return createHalResource<Match>("/matches", data, this.authStrategy, "match");
+    }
+
+    async deleteMatch(id: string): Promise<void> {
+        const matchId = encodeURIComponent(id);
+        await deleteHal(`/matches/${matchId}`, this.authStrategy);
     }
 }

--- a/src/api/scientificProjectApi.ts
+++ b/src/api/scientificProjectApi.ts
@@ -1,6 +1,6 @@
 import type { AuthStrategy } from "@/lib/authProvider";
 import { ScientificProject } from "@/types/scientificProject";
-import { getHal, mergeHal, mergeHalArray, postHal, fetchHalResource } from "./halClient";
+import { deleteHal, getHal, mergeHal, mergeHalArray, postHal, fetchHalResource } from "./halClient";
 
 export class ScientificProjectsService {
     constructor(private readonly authStrategy: AuthStrategy) { }
@@ -27,6 +27,11 @@ export class ScientificProjectsService {
         const resource = await postHal('/scientificProjects', project, this.authStrategy);
         if (!resource) throw new Error('Failed to create scientific project');
         return mergeHal<ScientificProject>(resource);
+    }
+
+    async deleteScientificProject(id: string): Promise<void> {
+        const projectId = encodeURIComponent(id);
+        await deleteHal(`/scientificProjects/${projectId}`, this.authStrategy);
     }
 
 }

--- a/src/app/matches/[id]/delete-match-dialog.tsx
+++ b/src/app/matches/[id]/delete-match-dialog.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { MatchesService } from "@/api/matchesApi";
+import ConfirmDestructiveDialog from "@/app/components/confirm-destructive-dialog";
+import { clientAuthProvider } from "@/lib/authProvider";
+
+interface DeleteMatchDialogProps {
+  readonly matchId: string;
+  readonly onCancel: () => void;
+}
+
+export default function DeleteMatchDialog({ matchId, onCancel }: DeleteMatchDialogProps) {
+  const router = useRouter();
+  const service = new MatchesService(clientAuthProvider);
+
+  async function handleDelete() {
+    await service.deleteMatch(matchId);
+    router.push("/matches");
+    router.refresh();
+  }
+
+  return (
+    <ConfirmDestructiveDialog
+      title="Delete match"
+      description={<p>Are you sure you want to delete this match? This action cannot be undone.</p>}
+      confirmLabel="Delete match"
+      pendingLabel="Deleting..."
+      onConfirm={handleDelete}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/src/app/matches/[id]/match-delete-section.tsx
+++ b/src/app/matches/[id]/match-delete-section.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/app/components/button";
+import DeleteMatchDialog from "./delete-match-dialog";
+
+interface MatchDeleteSectionProps {
+  readonly matchId: string;
+}
+
+export default function MatchDeleteSection({ matchId }: MatchDeleteSectionProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        onClick={() => setIsDialogOpen(true)}
+      >
+        Delete match
+      </Button>
+
+      {isDialogOpen && (
+        <DeleteMatchDialog
+          matchId={matchId}
+          onCancel={() => setIsDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -1,13 +1,17 @@
 import { MatchesService } from "@/api/matchesApi";
+import { UsersService } from "@/api/userApi";
 import ErrorAlert from "@/app/components/error-alert";
 import PageShell from "@/app/components/page-shell";
 import { serverAuthProvider } from "@/lib/authProvider";
+import { isAdmin } from "@/lib/authz";
 import { getEncodedResourceId } from "@/lib/halRoute";
 import { formatMatchTime } from "@/lib/matchUtils";
 import { NotFoundError, parseErrorMessage } from "@/types/errors";
 import { Match } from "@/types/match";
 import { Team } from "@/types/team";
+import { User } from "@/types/user";
 import Link from "next/link";
+import MatchDeleteSection from "./match-delete-section";
 
 export const dynamic = "force-dynamic";
 
@@ -92,8 +96,15 @@ export default async function MatchDetailPage(props: Readonly<MatchDetailPagePro
 
     let match: Match | null = null;
     let teams: Team[] = [];
+    let currentUser: User | null = null;
     let matchError: string | null = null;
     let teamsError: string | null = null;
+
+    try {
+        currentUser = await new UsersService(serverAuthProvider).getCurrentUser();
+    } catch {
+        // unauthenticated — delete button will not be shown
+    }
 
     try {
         match = await service.getMatchById(id);
@@ -124,6 +135,12 @@ export default async function MatchDetailPage(props: Readonly<MatchDetailPagePro
             description={match?.state ? `Status: ${match.state}` : undefined}
         >
             {matchError && <ErrorAlert message={matchError} />}
+
+            {!matchError && match && isAdmin(currentUser) && (
+                <div className="flex justify-end">
+                    <MatchDeleteSection matchId={id} />
+                </div>
+            )}
 
             {!matchError && match && (
                 <div className="space-y-8">

--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -102,8 +102,8 @@ export default async function MatchDetailPage(props: Readonly<MatchDetailPagePro
 
     try {
         currentUser = await new UsersService(serverAuthProvider).getCurrentUser();
-    } catch {
-        // unauthenticated — delete button will not be shown
+    } catch (e) {
+        console.error("Failed to fetch current user:", e);
     }
 
     try {

--- a/src/app/scientific-projects/[id]/delete-scientific-project-dialog.tsx
+++ b/src/app/scientific-projects/[id]/delete-scientific-project-dialog.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ScientificProjectsService } from "@/api/scientificProjectApi";
+import ConfirmDestructiveDialog from "@/app/components/confirm-destructive-dialog";
+import { clientAuthProvider } from "@/lib/authProvider";
+
+interface DeleteScientificProjectDialogProps {
+  readonly projectId: string;
+  readonly onCancel: () => void;
+}
+
+export default function DeleteScientificProjectDialog({ projectId, onCancel }: DeleteScientificProjectDialogProps) {
+  const router = useRouter();
+  const service = new ScientificProjectsService(clientAuthProvider);
+
+  async function handleDelete() {
+    await service.deleteScientificProject(projectId);
+    router.push("/scientific-projects");
+    router.refresh();
+  }
+
+  return (
+    <ConfirmDestructiveDialog
+      title="Delete scientific project"
+      description={<p>Are you sure you want to delete this scientific project? This action cannot be undone.</p>}
+      confirmLabel="Delete scientific project"
+      pendingLabel="Deleting..."
+      onConfirm={handleDelete}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/src/app/scientific-projects/[id]/page.tsx
+++ b/src/app/scientific-projects/[id]/page.tsx
@@ -1,13 +1,17 @@
 import { ScientificProjectsService } from "@/api/scientificProjectApi";
+import { UsersService } from "@/api/userApi";
 import ErrorAlert from "@/app/components/error-alert";
 import PageShell from "@/app/components/page-shell";
 import { InfoRow } from "@/app/components/info-row";
 import { TeamCard } from "@/app/components/team-card";
 import { serverAuthProvider } from "@/lib/authProvider";
+import { isAdmin } from "@/lib/authz";
 import { fetchHalResource } from "@/api/halClient";
 import { NotFoundError, parseErrorMessage } from "@/types/errors";
 import { ScientificProject } from "@/types/scientificProject";
 import { Team } from "@/types/team";
+import { User } from "@/types/user";
+import ScientificProjectDeleteSection from "./scientific-project-delete-section";
 
 export const dynamic = "force-dynamic";
 
@@ -30,8 +34,15 @@ export default async function ScientificProjectDetailPage(props: Readonly<Scient
 
     let project: ScientificProject | null = null;
     let team: Team | null = null;
+    let currentUser: User | null = null;
     let projectError: string | null = null;
     let teamError: string | null = null;
+
+    try {
+        currentUser = await new UsersService(serverAuthProvider).getCurrentUser();
+    } catch (e) {
+        console.error("Failed to fetch current user:", e);
+    }
 
     try {
         project = await service.getScientificProjectById(id);
@@ -59,6 +70,12 @@ export default async function ScientificProjectDetailPage(props: Readonly<Scient
             description={project?.score !== undefined && project?.score !== null ? `Score: ${project.score} pts` : undefined}
         >
             {projectError && <ErrorAlert message={projectError} />}
+
+            {!projectError && project && isAdmin(currentUser) && (
+                <div className="flex justify-end">
+                    <ScientificProjectDeleteSection projectId={id} />
+                </div>
+            )}
 
             {!projectError && project && (
                 <div className="space-y-8">

--- a/src/app/scientific-projects/[id]/scientific-project-delete-section.tsx
+++ b/src/app/scientific-projects/[id]/scientific-project-delete-section.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/app/components/button";
+import DeleteScientificProjectDialog from "./delete-scientific-project-dialog";
+
+interface ScientificProjectDeleteSectionProps {
+  readonly projectId: string;
+}
+
+export default function ScientificProjectDeleteSection({ projectId }: ScientificProjectDeleteSectionProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        onClick={() => setIsDialogOpen(true)}
+      >
+        Delete scientific project
+      </Button>
+
+      {isDialogOpen && (
+        <DeleteScientificProjectDialog
+          projectId={projectId}
+          onCancel={() => setIsDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Closes #65

Adds a delete button on the match detail page, visible only to administrators. Clicking it opens a confirmation dialog before performing the deletion and redirects to the matches list.
