### PR TITLE
feat: add volunteer detail page (#162)

### DIFF
--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -28,10 +28,7 @@ function toTeamMemberSnapshot(member: TeamMember): TeamMemberSnapshot {
 }
 
 function getTeamDisplayName(team: Team | null): string | null {
-    if (!team) {
-        return null;
-    }
-
+    if (!team) return null;
     return team.name ?? team.id ?? null;
 }
 
@@ -96,14 +93,21 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
     );
 
     const currentUserEmail = currentUser?.email?.trim().toLowerCase();
+
     const isCoach = !!currentUserEmail && coaches.some(
         (coach) => coach.emailAddress?.trim().toLowerCase() === currentUserEmail
     );
 
-    const coachName = coaches.length > 0
-        ? (coaches[0].name ?? coaches[0].emailAddress ?? "Unnamed coach")
-        : "No coach assigned";
+    // ✅ FIX PRINCIPAL: múltiples coaches
+    const coachName =
+        coaches.length > 0
+            ? coaches
+                .map(c => c.name ?? c.emailAddress ?? "Unnamed coach")
+                .join(", ")
+            : "No coach assigned";
+
     const initialMembers = members.map(toTeamMemberSnapshot);
+
     const membersKey = initialMembers
         .map((member) => member.uri ?? String(member.id ?? member.name ?? ""))
         .join("|");
@@ -112,14 +116,24 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
         <div className="flex min-h-screen items-center justify-center bg-background">
             <div className="w-full max-w-3xl px-4 py-10">
                 <div className="w-full rounded-lg border bg-white p-6 shadow-sm dark:bg-black">
-                    <h1 className="mb-2 text-2xl font-semibold">{teamDisplayName ?? "Unnamed team"}</h1>
+
+                    <h1 className="mb-2 text-2xl font-semibold">
+                        {teamDisplayName ?? "Unnamed team"}
+                    </h1>
 
                     <div className="mb-6 space-y-1 text-sm text-muted-foreground">
-                        {team.city && <p><strong>City:</strong> {team.city}</p>}
-                        <p><strong>Coach:</strong> {coachName}</p>
+                        {team.city && (
+                            <p><strong>City:</strong> {team.city}</p>
+                        )}
+
+                        <p>
+                            <strong>Coach:</strong> {coachName}
+                        </p>
                     </div>
 
-                    <h2 className="mt-8 mb-4 text-xl font-semibold">Team Members</h2>
+                    <h2 className="mt-8 mb-4 text-xl font-semibold">
+                        Team Members
+                    </h2>
 
                     {!membersError && (
                         <TeamMembersManager
@@ -130,7 +144,10 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
                             isAdmin={isAdmin}
                         />
                     )}
-                    {membersError && <ErrorAlert message={membersError} />}
+
+                    {membersError && (
+                        <ErrorAlert message={membersError} />
+                    )}
 
                     <section aria-labelledby="team-projects-heading">
                         <h2 id="team-projects-heading" className="mt-8 mb-4 text-xl font-semibold">
@@ -153,12 +170,17 @@ export default async function TeamDetailPage(props: Readonly<TeamDetailPageProps
                             <ul className="space-y-3">
                                 {scientificProjects.map((project, index) => (
                                     <li key={project.uri ?? project.link("self")?.href ?? index}>
-                                        <ScientificProjectCardLink project={project} index={index} variant="stacked" />
+                                        <ScientificProjectCardLink
+                                            project={project}
+                                            index={index}
+                                            variant="stacked"
+                                        />
                                     </li>
                                 ))}
                             </ul>
                         )}
                     </section>
+
                 </div>
             </div>
         </div>

--- a/src/app/volunteers/[id]/page.tsx
+++ b/src/app/volunteers/[id]/page.tsx
@@ -21,11 +21,9 @@ export default async function VolunteerDetailPage(props: Readonly<Props>) {
         const data = await service.getVolunteers();
         const all = [...data.judges, ...data.referees, ...data.floaters];
 
-        volunteer =
-            all.find(v => {
-                const candidate = `${v.type}-${v.name}`;
-                return encodeURIComponent(candidate) === id;
-            }) ?? null;
+        const decoded = decodeURIComponent(id);
+
+        volunteer = all.find(v => v.uri === decoded) ?? null;
 
     } catch (e) {
         console.error(e);
@@ -38,21 +36,21 @@ export default async function VolunteerDetailPage(props: Readonly<Props>) {
     return (
         <div className="flex min-h-screen items-center justify-center bg-background">
             <div className="w-full max-w-3xl px-4 py-10">
-                <div className="rounded-lg border bg-white p-6 shadow-sm dark:bg-black">
+                <div className="w-full rounded-lg border bg-white p-6 shadow-sm dark:bg-black">
 
-                    <h1 className="text-2xl font-semibold mb-2">
+                    <h1 className="mb-2 text-2xl font-semibold">
                         {volunteer.name || "Unnamed volunteer"}
                     </h1>
 
-                    <div className="space-y-1 text-sm text-muted-foreground mb-6">
+                    <div className="mb-6 space-y-1 text-sm text-muted-foreground">
                         <p><strong>Role:</strong> {volunteer.type}</p>
-                        <p><strong>Email:</strong> {volunteer.emailAddress}</p>
-                        <p><strong>Phone:</strong> {volunteer.phoneNumber}</p>
+                        <p><strong>Email:</strong> {volunteer.emailAddress || "—"}</p>
+                        <p><strong>Phone:</strong> {volunteer.phoneNumber || "—"}</p>
                     </div>
 
                     {volunteer.type === "Judge" && (
-                        <div>
-                            <h2 className="font-semibold">Judge Info</h2>
+                        <div className="mt-6 space-y-2">
+                            <h2 className="text-xl font-semibold">Judge Info</h2>
                             <p><strong>Expert:</strong> {volunteer.expert ? "Yes" : "No"}</p>
                         </div>
                     )}

--- a/src/app/volunteers/[id]/page.tsx
+++ b/src/app/volunteers/[id]/page.tsx
@@ -21,14 +21,11 @@ export default async function VolunteerDetailPage(props: Readonly<Props>) {
         const data = await service.getVolunteers();
         const all = [...data.judges, ...data.referees, ...data.floaters];
 
-        const decoded = decodeURIComponent(id);
-
-        volunteer = all.find((_, idx) => {
-            const encoded = encodeURIComponent(
-                `${all[idx].type}-${all[idx].name}-${idx}`
-            );
-            return encoded === id;
-        }) ?? null;
+        volunteer =
+            all.find(v => {
+                const candidate = `${v.type}-${v.name}`;
+                return encodeURIComponent(candidate) === id;
+            }) ?? null;
 
     } catch (e) {
         console.error(e);
@@ -41,21 +38,21 @@ export default async function VolunteerDetailPage(props: Readonly<Props>) {
     return (
         <div className="flex min-h-screen items-center justify-center bg-background">
             <div className="w-full max-w-3xl px-4 py-10">
-                <div className="w-full rounded-lg border bg-white p-6 shadow-sm dark:bg-black">
+                <div className="rounded-lg border bg-white p-6 shadow-sm dark:bg-black">
 
-                    <h1 className="mb-2 text-2xl font-semibold">
+                    <h1 className="text-2xl font-semibold mb-2">
                         {volunteer.name || "Unnamed volunteer"}
                     </h1>
 
-                    <div className="mb-6 space-y-1 text-sm text-muted-foreground">
+                    <div className="space-y-1 text-sm text-muted-foreground mb-6">
                         <p><strong>Role:</strong> {volunteer.type}</p>
                         <p><strong>Email:</strong> {volunteer.emailAddress}</p>
                         <p><strong>Phone:</strong> {volunteer.phoneNumber}</p>
                     </div>
 
                     {volunteer.type === "Judge" && (
-                        <div className="mt-6 space-y-2">
-                            <h2 className="text-xl font-semibold">Judge Info</h2>
+                        <div>
+                            <h2 className="font-semibold">Judge Info</h2>
                             <p><strong>Expert:</strong> {volunteer.expert ? "Yes" : "No"}</p>
                         </div>
                     )}

--- a/src/app/volunteers/[id]/page.tsx
+++ b/src/app/volunteers/[id]/page.tsx
@@ -1,0 +1,67 @@
+import { VolunteersService } from "@/api/volunteerApi";
+import EmptyState from "@/app/components/empty-state";
+import ErrorAlert from "@/app/components/error-alert";
+import { serverAuthProvider } from "@/lib/authProvider";
+import { parseErrorMessage } from "@/types/errors";
+import { Volunteer } from "@/types/volunteer";
+
+interface Props {
+    params: Promise<{ id: string }>;
+}
+
+export default async function VolunteerDetailPage(props: Readonly<Props>) {
+    const { id } = await props.params;
+
+    const service = new VolunteersService(serverAuthProvider);
+
+    let volunteer: Volunteer | null = null;
+    let error: string | null = null;
+
+    try {
+        const data = await service.getVolunteers();
+        const all = [...data.judges, ...data.referees, ...data.floaters];
+
+        const decoded = decodeURIComponent(id);
+
+        volunteer = all.find((_, idx) => {
+            const encoded = encodeURIComponent(
+                `${all[idx].type}-${all[idx].name}-${idx}`
+            );
+            return encoded === id;
+        }) ?? null;
+
+    } catch (e) {
+        console.error(e);
+        error = parseErrorMessage(e);
+    }
+
+    if (error) return <ErrorAlert message={error} />;
+    if (!volunteer) return <EmptyState title="Not found" description="Volunteer does not exist" />;
+
+    return (
+        <div className="flex min-h-screen items-center justify-center bg-background">
+            <div className="w-full max-w-3xl px-4 py-10">
+                <div className="w-full rounded-lg border bg-white p-6 shadow-sm dark:bg-black">
+
+                    <h1 className="mb-2 text-2xl font-semibold">
+                        {volunteer.name || "Unnamed volunteer"}
+                    </h1>
+
+                    <div className="mb-6 space-y-1 text-sm text-muted-foreground">
+                        <p><strong>Role:</strong> {volunteer.type}</p>
+                        <p><strong>Email:</strong> {volunteer.emailAddress}</p>
+                        <p><strong>Phone:</strong> {volunteer.phoneNumber}</p>
+                    </div>
+
+                    {volunteer.type === "Judge" && (
+                        <div className="mt-6 space-y-2">
+                            <h2 className="text-xl font-semibold">Judge Info</h2>
+                            <p><strong>Expert:</strong> {volunteer.expert ? "Yes" : "No"}</p>
+                        </div>
+                    )}
+
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/volunteers/_volunteers-client.tsx
+++ b/src/app/volunteers/_volunteers-client.tsx
@@ -18,50 +18,42 @@ interface VolunteersClientProps {
     floaters: VolunteerItem[];
 }
 
-interface VolunteerSectionProps {
-    title: string;
-    typePlural: string;
-    volunteers: VolunteerItem[];
-    emptyMessage: string;
-}
-
 function filterByName(volunteers: VolunteerItem[], query: string): VolunteerItem[] {
     const q = query.trim().toLowerCase();
     if (!q) return volunteers;
     return volunteers.filter(v => v.name?.toLowerCase().includes(q));
 }
 
-function VolunteerSection({ title, typePlural, volunteers, emptyMessage }: Readonly<VolunteerSectionProps>) {
+function VolunteerSection({ title, typePlural, volunteers, emptyMessage }: any) {
     const [query, setQuery] = useState('');
     const filtered = filterByName(volunteers, query);
 
     return (
         <div className="space-y-4 pt-4">
-            <h3 className="text-xl font-semibold tracking-tight">{title}</h3>
+            <h3 className="text-xl font-semibold">{title}</h3>
 
             <Input
                 type="search"
-                placeholder={`Search ${typePlural} by name...`}
+                placeholder={`Search ${typePlural}`}
                 value={query}
                 onChange={e => setQuery(e.target.value)}
             />
 
             {filtered.length === 0 ? (
-                <EmptyState
-                    title={`No ${typePlural} found`}
-                    description={emptyMessage}
-                />
+                <EmptyState title={`No ${typePlural} found`} description={emptyMessage} />
             ) : (
                 <ul className="list-grid">
-                    {filtered.map((v, idx) => {
-                        const encoded = encodeURIComponent(`${v.type}-${v.name}-${idx}`);
+                    {filtered.map((v) => {
+
+                        const id = `${v.type}-${v.name}`;
+                        const encoded = encodeURIComponent(id);
 
                         return (
-                            <li key={encoded} className="list-card pl-7">
+                            <li key={id} className="list-card pl-7">
                                 <div className="list-kicker">{v.type}</div>
 
                                 <Link href={`/volunteers/${encoded}`}>
-                                    <div className="list-title font-medium cursor-pointer hover:underline">
+                                    <div className="list-title cursor-pointer hover:underline">
                                         {v.name || 'Unknown'}
                                     </div>
                                 </Link>
@@ -78,27 +70,12 @@ function VolunteerSection({ title, typePlural, volunteers, emptyMessage }: Reado
     );
 }
 
-export default function VolunteersClient({ judges, referees, floaters }: Readonly<VolunteersClientProps>) {
+export default function VolunteersClient({ judges, referees, floaters }: VolunteersClientProps) {
     return (
-        <div className="space-y-12 shrink-0">
-            <VolunteerSection
-                title="Judges"
-                typePlural="judges"
-                volunteers={judges}
-                emptyMessage="There are currently no judges registered for the competition."
-            />
-            <VolunteerSection
-                title="Referees"
-                typePlural="referees"
-                volunteers={referees}
-                emptyMessage="There are currently no referees registered for the competition."
-            />
-            <VolunteerSection
-                title="Floaters"
-                typePlural="floaters"
-                volunteers={floaters}
-                emptyMessage="There are currently no floaters registered for the competition."
-            />
+        <div className="space-y-12">
+            <VolunteerSection title="Judges" typePlural="judges" volunteers={judges} emptyMessage="" />
+            <VolunteerSection title="Referees" typePlural="referees" volunteers={referees} emptyMessage="" />
+            <VolunteerSection title="Floaters" typePlural="floaters" volunteers={floaters} emptyMessage="" />
         </div>
     );
 }

--- a/src/app/volunteers/_volunteers-client.tsx
+++ b/src/app/volunteers/_volunteers-client.tsx
@@ -10,6 +10,7 @@ export interface VolunteerItem {
     name?: string;
     emailAddress?: string;
     type?: VolunteerRole;
+    uri?: string;
 }
 
 interface VolunteersClientProps {
@@ -18,13 +19,25 @@ interface VolunteersClientProps {
     floaters: VolunteerItem[];
 }
 
+interface VolunteerSectionProps {
+    title: string;
+    typePlural: string;
+    volunteers: VolunteerItem[];
+    emptyMessage: string;
+}
+
 function filterByName(volunteers: VolunteerItem[], query: string): VolunteerItem[] {
     const q = query.trim().toLowerCase();
     if (!q) return volunteers;
     return volunteers.filter(v => v.name?.toLowerCase().includes(q));
 }
 
-function VolunteerSection({ title, typePlural, volunteers, emptyMessage }: any) {
+function VolunteerSection({
+    title,
+    typePlural,
+    volunteers,
+    emptyMessage,
+}: Readonly<VolunteerSectionProps>) {
     const [query, setQuery] = useState('');
     const filtered = filterByName(volunteers, query);
 
@@ -40,20 +53,18 @@ function VolunteerSection({ title, typePlural, volunteers, emptyMessage }: any) 
             />
 
             {filtered.length === 0 ? (
-                <EmptyState title={`No ${typePlural} found`} description={emptyMessage} />
+                <EmptyState title={`No ${typePlural}`} description={emptyMessage} />
             ) : (
                 <ul className="list-grid">
                     {filtered.map((v) => {
-
-                        const id = `${v.type}-${v.name}`;
-                        const encoded = encodeURIComponent(id);
+                        const id = v.uri ? encodeURIComponent(v.uri) : '';
 
                         return (
                             <li key={id} className="list-card pl-7">
                                 <div className="list-kicker">{v.type}</div>
 
-                                <Link href={`/volunteers/${encoded}`}>
-                                    <div className="list-title cursor-pointer hover:underline">
+                                <Link href={`/volunteers/${id}`}>
+                                    <div className="list-title font-medium hover:underline cursor-pointer">
                                         {v.name || 'Unknown'}
                                     </div>
                                 </Link>
@@ -70,12 +81,31 @@ function VolunteerSection({ title, typePlural, volunteers, emptyMessage }: any) 
     );
 }
 
-export default function VolunteersClient({ judges, referees, floaters }: VolunteersClientProps) {
+export default function VolunteersClient({
+    judges,
+    referees,
+    floaters,
+}: Readonly<VolunteersClientProps>) {
     return (
         <div className="space-y-12">
-            <VolunteerSection title="Judges" typePlural="judges" volunteers={judges} emptyMessage="" />
-            <VolunteerSection title="Referees" typePlural="referees" volunteers={referees} emptyMessage="" />
-            <VolunteerSection title="Floaters" typePlural="floaters" volunteers={floaters} emptyMessage="" />
+            <VolunteerSection
+                title="Judges"
+                typePlural="judges"
+                volunteers={judges}
+                emptyMessage="No judges available"
+            />
+            <VolunteerSection
+                title="Referees"
+                typePlural="referees"
+                volunteers={referees}
+                emptyMessage="No referees available"
+            />
+            <VolunteerSection
+                title="Floaters"
+                typePlural="floaters"
+                volunteers={floaters}
+                emptyMessage="No floaters available"
+            />
         </div>
     );
 }

--- a/src/app/volunteers/_volunteers-client.tsx
+++ b/src/app/volunteers/_volunteers-client.tsx
@@ -4,6 +4,7 @@ import EmptyState from '@/app/components/empty-state';
 import { Input } from '@/app/components/input';
 import { VolunteerRole } from '@/types/volunteer';
 import { useState } from 'react';
+import Link from 'next/link';
 
 export interface VolunteerItem {
     name?: string;
@@ -37,27 +38,37 @@ function VolunteerSection({ title, typePlural, volunteers, emptyMessage }: Reado
     return (
         <div className="space-y-4 pt-4">
             <h3 className="text-xl font-semibold tracking-tight">{title}</h3>
+
             <Input
                 type="search"
                 placeholder={`Search ${typePlural} by name...`}
                 value={query}
                 onChange={e => setQuery(e.target.value)}
-                aria-label={`Search ${typePlural}`}
             />
+
             {filtered.length === 0 ? (
                 <EmptyState
-                    title={query ? `No ${typePlural} match "${query}"` : `No ${typePlural} found`}
-                    description={query ? 'Try a different search term.' : emptyMessage}
+                    title={`No ${typePlural} found`}
+                    description={emptyMessage}
                 />
             ) : (
                 <ul className="list-grid">
                     {filtered.map((v, idx) => {
-                        const id = v.name ? `${v.type}-${v.name}-${idx}` : `${v.type}-${idx}`;
+                        const encoded = encodeURIComponent(`${v.type}-${v.name}-${idx}`);
+
                         return (
-                            <li key={id} className="list-card pl-7">
+                            <li key={encoded} className="list-card pl-7">
                                 <div className="list-kicker">{v.type}</div>
-                                <div className="list-title block font-medium">{v.name || 'Unknown'}</div>
-                                {v.emailAddress && <div className="list-support">{v.emailAddress}</div>}
+
+                                <Link href={`/volunteers/${encoded}`}>
+                                    <div className="list-title font-medium cursor-pointer hover:underline">
+                                        {v.name || 'Unknown'}
+                                    </div>
+                                </Link>
+
+                                {v.emailAddress && (
+                                    <div className="list-support">{v.emailAddress}</div>
+                                )}
                             </li>
                         );
                     })}

--- a/src/app/volunteers/page.tsx
+++ b/src/app/volunteers/page.tsx
@@ -28,7 +28,7 @@ export default async function VolunteersPage() {
         referees = data.referees.map(toVolunteerItem);
         floaters = data.floaters.map(toVolunteerItem);
     } catch (e) {
-        console.error("Failed to fetch volunteers:", e);
+        console.error(e);
         error = parseErrorMessage(e);
     }
 
@@ -36,7 +36,7 @@ export default async function VolunteersPage() {
         <PageShell
             eyebrow="Volunteers directory"
             title="Volunteers"
-            description="Manage the competition volunteers including judges, referees, and floaters."
+            description="Manage volunteers"
         >
             <div className="space-y-8">
                 {error && <ErrorAlert message={error} />}

--- a/src/app/volunteers/page.tsx
+++ b/src/app/volunteers/page.tsx
@@ -11,6 +11,7 @@ function toVolunteerItem(v: Volunteer): VolunteerItem {
         name: v.name,
         emailAddress: v.emailAddress,
         type: v.type,
+        uri: v.uri
     };
 }
 
@@ -28,7 +29,7 @@ export default async function VolunteersPage() {
         referees = data.referees.map(toVolunteerItem);
         floaters = data.floaters.map(toVolunteerItem);
     } catch (e) {
-        console.error(e);
+        console.error("Failed to fetch volunteers:", e);
         error = parseErrorMessage(e);
     }
 
@@ -36,7 +37,7 @@ export default async function VolunteersPage() {
         <PageShell
             eyebrow="Volunteers directory"
             title="Volunteers"
-            description="Manage volunteers"
+            description="Manage the competition volunteers including judges, referees, and floaters."
         >
             <div className="space-y-8">
                 {error && <ErrorAlert message={error} />}

--- a/src/app/volunteers/page.tsx
+++ b/src/app/volunteers/page.tsx
@@ -7,11 +7,16 @@ import { Volunteer } from "@/types/volunteer";
 import VolunteersClient, { VolunteerItem } from "./_volunteers-client";
 
 function toVolunteerItem(v: Volunteer): VolunteerItem {
-    return { name: v.name, emailAddress: v.emailAddress, type: v.type };
+    return {
+        name: v.name,
+        emailAddress: v.emailAddress,
+        type: v.type,
+    };
 }
 
 export default async function VolunteersPage() {
     const service = new VolunteersService(serverAuthProvider);
+
     let judges: VolunteerItem[] = [];
     let referees: VolunteerItem[] = [];
     let floaters: VolunteerItem[] = [];
@@ -37,7 +42,11 @@ export default async function VolunteersPage() {
                 {error && <ErrorAlert message={error} />}
 
                 {!error && (
-                    <VolunteersClient judges={judges} referees={referees} floaters={floaters} />
+                    <VolunteersClient
+                        judges={judges}
+                        referees={referees}
+                        floaters={floaters}
+                    />
                 )}
             </div>
         </PageShell>


### PR DESCRIPTION
## Summary

This PR includes two improvements in the application:

### 1. Volunteer feature
Implements navigation and detailed view for individual volunteers at `/volunteers/[id]`, allowing users to access full volunteer information.

### 2. Team feature
Fixes coach display in team detail page to properly support multiple coaches instead of showing only the first one.

---

## Changes

### Volunteer feature
- Made volunteer names clickable in `/volunteers` list
- Added dynamic route `/volunteers/[id]/page.tsx`
- Fixed stable navigation between list and detail views
- Fetch volunteer details from API
- Display full volunteer information:
  - name
  - role
  - email
  - phone
  - expert info (for judges)
- Added error state for invalid or non-existent volunteers
- Ensured consistent encoding between list and detail pages
- Restricted access to authenticated users only

### Team feature
- Replaced single coach display (`coaches[0]`) with array rendering
- Now supports multiple coaches per team
- Handles empty state when no coaches are assigned
- Improves robustness of team detail view

---

## Fixes

- Fixed inconsistent volunteer ID generation between list and detail pages
- Fixed "Not found" issue caused by unstable index-based encoding
- Fixed coach display limitation in team detail page

---

## How to test

### Volunteers
- Go to `/volunteers`
- Click on a volunteer name
- Verify navigation to `/volunteers/[id]`
- Check details are displayed correctly
- Try invalid ID → error state appears

### Teams
- Go to `/teams/[id]`
- Verify all coaches are displayed
- Check correct fallback when no coaches exist
- Verify single coach case works correctly

---

## Notes

- No backend changes required
- Uses existing authentication system
- Follows project UI patterns
- Fully backward compatible

---

## Related issues

Closes #162
Closes #184