### PR TITLE
feat: add admin award deletion controls

### DIFF
--- a/e2e/editions.spec.ts
+++ b/e2e/editions.spec.ts
@@ -1,4 +1,14 @@
 import { expect, test } from "@playwright/test";
+import { hasAdminTestUser } from "./utils/api";
+import { loginViaUi } from "./utils/auth";
+
+function getAdminUser() {
+    return {
+        username: process.env.E2E_ADMIN_USERNAME ?? "",
+        password: process.env.E2E_ADMIN_PASSWORD ?? "",
+        email: `${process.env.E2E_ADMIN_USERNAME ?? "admin"}@sample.app`,
+    };
+}
 
 test("editions page links to an edition detail page", async ({ page }) => {
     await page.goto("/editions");
@@ -19,4 +29,27 @@ test("editions page links to an edition detail page", async ({ page }) => {
 
     await expect(page).toHaveURL(/\/editions\/.+$/);
     await expect(page.getByRole("heading", { name: "Participating Teams", level: 2 })).toBeVisible();
+});
+
+test.describe("edition award delete controls", () => {
+    test.beforeEach(async ({ page }) => {
+        test.skip(!hasAdminTestUser(), "Admin credentials not configured");
+        await loginViaUi(page, getAdminUser());
+        await page.goto("/editions/1");
+        await expect(page.getByRole("heading", { name: "Participating Teams", level: 2 })).toBeVisible();
+    });
+
+    test("admins can open and cancel the award delete dialog", async ({ page }) => {
+        const deleteButton = page.getByRole("button", { name: "Delete Champion Award" });
+
+        await expect(deleteButton).toBeVisible();
+        await deleteButton.click();
+
+        const dialog = page.getByRole("dialog", { name: "Delete award" });
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByText("Champion Award")).toBeVisible();
+
+        await page.getByRole("button", { name: "Cancel" }).click();
+        await expect(dialog).not.toBeVisible();
+    });
 });

--- a/e2e/editions.spec.ts
+++ b/e2e/editions.spec.ts
@@ -6,7 +6,6 @@ function getAdminUser() {
     return {
         username: process.env.E2E_ADMIN_USERNAME ?? "",
         password: process.env.E2E_ADMIN_PASSWORD ?? "",
-        email: `${process.env.E2E_ADMIN_USERNAME ?? "admin"}@sample.app`,
     };
 }
 
@@ -52,4 +51,72 @@ test.describe("edition award delete controls", () => {
         await page.getByRole("button", { name: "Cancel" }).click();
         await expect(dialog).not.toBeVisible();
     });
+
+    test("admins can delete an award and the page refreshes without the award", async ({ page }) => {
+        let deletedAwardUri: string | null = null;
+        let awardDeleted = false;
+
+        await page.route("**/awards/search/findByEdition**", async (route) => {
+            const response = await route.fetch();
+            const body = await response.json();
+            const awards = body._embedded?.awards ?? [];
+
+            if (!deletedAwardUri) {
+                const matchingAward = awards.find((award: { name?: string; title?: string; category?: string }) =>
+                    award.name === "Champion Award" || award.title === "Champion Award" || award.category === "Champion Award"
+                );
+                const selectedAward = matchingAward ?? awards[0];
+                deletedAwardUri = selectedAward?._links?.self?.href ?? selectedAward?.uri ?? null;
+            }
+
+            if (awardDeleted && deletedAwardUri) {
+                body._embedded = {
+                    ...(body._embedded ?? {}),
+                    awards: awards.filter((award: { _links?: { self?: { href?: string } }; uri?: string }) => {
+                        const awardUri = award._links?.self?.href ?? award.uri;
+                        return awardUri !== deletedAwardUri;
+                    }),
+                };
+            }
+
+            await route.fulfill({ response, json: body });
+        });
+
+        await page.goto("/editions/1");
+        await expect(page.getByRole("heading", { name: "Participating Teams", level: 2 })).toBeVisible();
+
+        const deleteButton = page.getByRole("button", { name: "Delete Champion Award" });
+        await expect(deleteButton).toBeVisible();
+        await expect(page.getByText("Champion Award")).toBeVisible();
+
+        if (!deletedAwardUri) {
+            throw new Error("Could not determine the award URI.");
+        }
+
+        await page.route(`**${new URL(deletedAwardUri, "http://localhost").pathname}`, async (route) => {
+            if (route.request().method() === "DELETE") {
+                awardDeleted = true;
+                await route.fulfill({ status: 204, body: "" });
+                return;
+            }
+
+            await route.continue();
+        });
+
+        await deleteButton.click();
+        const dialog = page.getByRole("dialog", { name: "Delete award" });
+        await expect(dialog).toBeVisible();
+        await page.getByRole("button", { name: "Delete award" }).click();
+
+        await expect(deleteButton).not.toBeVisible();
+        await expect(page.getByText("Champion Award")).not.toBeVisible();
+    });
+});
+
+test("non-admin users cannot see award delete controls", async ({ page }) => {
+    await page.goto("/editions/1");
+
+    await expect(page.getByRole("heading", { name: "Participating Teams", level: 2 })).toBeVisible();
+    await expect(page.getByText("Champion Award")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Delete Champion Award" })).toHaveCount(0);
 });

--- a/src/api/awardApi.ts
+++ b/src/api/awardApi.ts
@@ -1,7 +1,7 @@
 import type { AuthStrategy } from "@/lib/authProvider";
 import { Award } from "@/types/award";
 import { Team } from "@/types/team";
-import { fetchHalCollection, fetchHalResource } from "./halClient";
+import { deleteHal, fetchHalCollection, fetchHalResource } from "./halClient";
 
 function getResourceUri(resource: Team & { link: (relation: string) => { href?: string } | undefined }): string | null {
     return resource.uri ?? resource.link("self")?.href ?? null;
@@ -35,5 +35,9 @@ export class AwardsService {
                 winnerTeam: winnerTeamUri,
             });
         }));
+    }
+
+    async deleteAward(awardUri: string): Promise<void> {
+        await deleteHal(awardUri, this.authStrategy);
     }
 }

--- a/src/app/editions/[id]/actions.ts
+++ b/src/app/editions/[id]/actions.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { AwardsService } from "@/api/awardApi";
+import { UsersService } from "@/api/userApi";
+import { serverAuthProvider } from "@/lib/authProvider";
+import { isAdmin } from "@/lib/authz";
+import { AuthenticationError } from "@/types/errors";
+import { revalidatePath } from "next/cache";
+
+function parseErrorMessage(error: unknown): string | undefined {
+  if (error instanceof AuthenticationError && error.message) {
+    return error.message;
+  }
+
+  return undefined;
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return parseErrorMessage(error) ?? fallback;
+}
+
+async function assertAdminAccess() {
+  const auth = await serverAuthProvider.getAuth();
+  if (!auth) {
+    throw new AuthenticationError();
+  }
+
+  const currentUser = await new UsersService(serverAuthProvider).getCurrentUser();
+
+  if (!isAdmin(currentUser)) {
+    throw new AuthenticationError("You are not allowed to delete awards.", 403);
+  }
+}
+
+export async function deleteAward(editionId: string, awardUri: string) {
+  try {
+    await assertAdminAccess();
+
+    await new AwardsService(serverAuthProvider).deleteAward(awardUri);
+
+    revalidatePath(`/editions/${editionId}`);
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: getErrorMessage(error, "Error deleting the award"),
+    };
+  }
+}

--- a/src/app/editions/[id]/award-delete-section.tsx
+++ b/src/app/editions/[id]/award-delete-section.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/app/components/button";
+import ConfirmDestructiveDialog from "@/app/components/confirm-destructive-dialog";
+import { deleteAward } from "./actions";
+
+interface AwardDeleteSectionProps {
+  readonly editionId: string;
+  readonly awardLabel: string;
+  readonly awardUri: string;
+}
+
+export default function AwardDeleteSection({
+  editionId,
+  awardLabel,
+  awardUri,
+}: AwardDeleteSectionProps) {
+  const router = useRouter();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        className="ml-1 h-6 w-6 rounded-full border-0 text-amber-900 hover:bg-amber-200 hover:text-destructive"
+        aria-label={`Delete ${awardLabel}`}
+        title={`Delete ${awardLabel}`}
+        onClick={() => setIsDialogOpen(true)}
+      >
+        <Trash2 className="size-3.5" aria-hidden="true" />
+      </Button>
+
+      {isDialogOpen && (
+        <ConfirmDestructiveDialog
+          title="Delete award"
+          description={
+            <p>
+              Are you sure you want to delete <span className="font-semibold text-foreground">{awardLabel}</span>?
+              This action cannot be undone.
+            </p>
+          }
+          confirmLabel="Delete award"
+          pendingLabel="Deleting..."
+          onConfirm={async () => {
+            const result = await deleteAward(editionId, awardUri);
+            if (!result.success) {
+              throw new Error(result.error ?? "Error deleting the award");
+            }
+
+            setIsDialogOpen(false);
+            router.refresh();
+          }}
+          onCancel={() => setIsDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/editions/[id]/page.tsx
+++ b/src/app/editions/[id]/page.tsx
@@ -7,6 +7,7 @@ import EmptyState from "@/app/components/empty-state";
 import LeaderboardTable from "@/app/components/leaderboard-table";
 import { MediaItem } from "@/app/components/media-gallery";
 import { MediaSection } from "@/app/components/media-section";
+import AwardDeleteSection from "./award-delete-section";
 import { serverAuthProvider } from "@/lib/authProvider";
 import type { LeaderboardItem } from "@/types/leaderboard";
 import { getEncodedResourceId } from "@/lib/halRoute";
@@ -40,6 +41,10 @@ function getEditionTitle(edition: Edition | null, id: string) {
 
 function getAwardLabel(award: Award, fallbackIndex: number): string {
     return award.name ?? award.title ?? award.category ?? `Award ${fallbackIndex + 1}`;
+}
+
+function getAwardResourceUri(award: Award): string | null {
+    return award.link("self")?.href ?? award.uri ?? null;
 }
 
 function getAwardWinnerTeamUri(award: Award): string | null {
@@ -254,14 +259,26 @@ export default async function EditionDetailPage(props: Readonly<EditionDetailPag
                                                         </span>
                                                     )}
 
-                                                    {teamAwards.map((award, awardIndex) => (
-                                                        <span
-                                                            key={award.uri ?? `${team.uri ?? index}-${awardIndex}`}
-                                                            className="inline-flex items-center rounded-full border border-amber-300 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-900"
-                                                        >
-                                                            {getAwardLabel(award, awardIndex)}
-                                                        </span>
-                                                    ))}
+                                                    {teamAwards.map((award, awardIndex) => {
+                                                        const awardLabel = getAwardLabel(award, awardIndex);
+                                                        const awardUri = getAwardResourceUri(award);
+
+                                                        return (
+                                                            <span
+                                                                key={award.uri ?? `${team.uri ?? index}-${awardIndex}`}
+                                                                className="inline-flex items-center rounded-full border border-amber-300 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-900"
+                                                            >
+                                                                {awardLabel}
+                                                                {currentUser && isAdmin(currentUser) && awardUri && (
+                                                                    <AwardDeleteSection
+                                                                        editionId={id}
+                                                                        awardLabel={awardLabel}
+                                                                        awardUri={awardUri}
+                                                                    />
+                                                                )}
+                                                            </span>
+                                                        );
+                                                    })}
                                                 </div>
                                             </li>
                                         );


### PR DESCRIPTION
## Summary
- add an admin-only award deletion action on edition detail pages
- confirm deletions in a destructive dialog and refresh the page after success
- add Playwright coverage for the award delete cancel flow, the successful delete flow, and non-admin visibility

## Testing
- npm run lint -- e2e/editions.spec.ts
- npx playwright test e2e/editions.spec.ts --list

Fixes #206