### PR TITLE
feat(competition-tables): add table management and referee assignment…

### DIFF
--- a/src/api/competitionTableApi.ts
+++ b/src/api/competitionTableApi.ts
@@ -48,6 +48,14 @@ export class CompetitionTableService {
         );
     }
 
+    async getRefereesForTable(tableId: string): Promise<Referee[]> {
+        return fetchHalCollection<Referee>(
+            `/competitionTables/${encodeURIComponent(tableId)}/referees`,
+            this.authStrategy,
+            "referees"
+        );
+    }
+
     async assignRefereeToTable(refereeHref: string, tableId: string): Promise<void> {
         await patchHal(refereeHref, { supervisesTable: `${API_BASE_URL}/competitionTables/${encodeURIComponent(tableId)}` }, this.authStrategy);
     }

--- a/src/api/competitionTableApi.ts
+++ b/src/api/competitionTableApi.ts
@@ -1,0 +1,58 @@
+import type { AuthStrategy } from "@/lib/authProvider";
+import { CompetitionTable } from "@/types/competitionTable";
+import { Referee } from "@/types/referee";
+import { API_BASE_URL, createHalResource, deleteHal, fetchHalCollection, patchHal } from "./halClient";
+
+export function getTableId(table: CompetitionTable): string {
+    const href = table.link("self")?.href ?? "";
+    const parts = href.split("/competitionTables/");
+    return parts.length > 1 ? decodeURIComponent(parts[1]) : "";
+}
+
+export function getRefereeAssignedTableId(referee: Referee): string | null {
+    const href = referee.link("supervisesTable")?.href;
+    if (!href) return null;
+    const parts = href.split("/competitionTables/");
+    return parts.length > 1 ? decodeURIComponent(parts[1]) : null;
+}
+
+export class CompetitionTableService {
+    constructor(private readonly authStrategy: AuthStrategy) {}
+
+    async getTables(): Promise<CompetitionTable[]> {
+        return fetchHalCollection<CompetitionTable>(
+            "/competitionTables?size=1000",
+            this.authStrategy,
+            "competitionTables"
+        );
+    }
+
+    async createTable(identifier: string): Promise<CompetitionTable> {
+        return createHalResource<CompetitionTable>(
+            "/competitionTables",
+            { id: identifier },
+            this.authStrategy,
+            "competition table"
+        );
+    }
+
+    async deleteTable(tableId: string): Promise<void> {
+        await deleteHal(`/competitionTables/${encodeURIComponent(tableId)}`, this.authStrategy);
+    }
+
+    async getReferees(): Promise<Referee[]> {
+        return fetchHalCollection<Referee>(
+            "/referees?sort=name,asc&size=1000",
+            this.authStrategy,
+            "referees"
+        );
+    }
+
+    async assignRefereeToTable(refereeHref: string, tableId: string): Promise<void> {
+        await patchHal(refereeHref, { supervisesTable: `${API_BASE_URL}/competitionTables/${encodeURIComponent(tableId)}` }, this.authStrategy);
+    }
+
+    async removeRefereeFromTable(refereeHref: string): Promise<void> {
+        await patchHal(refereeHref, { supervisesTable: null }, this.authStrategy);
+    }
+}

--- a/src/api/competitionTableApi.ts
+++ b/src/api/competitionTableApi.ts
@@ -9,12 +9,6 @@ export function getTableId(table: CompetitionTable): string {
     return parts.length > 1 ? decodeURIComponent(parts[1]) : "";
 }
 
-export function getRefereeAssignedTableId(referee: Referee): string | null {
-    const href = referee.link("supervisesTable")?.href;
-    if (!href) return null;
-    const parts = href.split("/competitionTables/");
-    return parts.length > 1 ? decodeURIComponent(parts[1]) : null;
-}
 
 export class CompetitionTableService {
     constructor(private readonly authStrategy: AuthStrategy) {}

--- a/src/app/competition-tables/assign-referee-dialog.tsx
+++ b/src/app/competition-tables/assign-referee-dialog.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { AlertCircle, UserCheck, X } from "lucide-react";
+import { Button } from "@/app/components/button";
+import { CompetitionTableService } from "@/api/competitionTableApi";
+import { clientAuthProvider } from "@/lib/authProvider";
+import { parseErrorMessage } from "@/types/errors";
+
+export interface RefereeOption {
+    href: string;
+    name: string;
+    emailAddress: string;
+    assignedTableId: string | null;
+}
+
+interface AssignRefereeDialogProps {
+    tableId: string;
+    currentReferees: RefereeOption[];
+    allReferees: RefereeOption[];
+    onClose: () => void;
+}
+
+export default function AssignRefereeDialog({ tableId, currentReferees, allReferees, onClose }: AssignRefereeDialogProps) {
+    const router = useRouter();
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [search, setSearch] = useState("");
+    const [pendingHref, setPendingHref] = useState<string | null>(null);
+
+    const service = new CompetitionTableService(clientAuthProvider);
+
+    const currentRefereeHrefs = new Set(currentReferees.map(r => r.href));
+    const filteredReferees = allReferees.filter(r =>
+        r.name.toLowerCase().includes(search.toLowerCase()) ||
+        r.emailAddress.toLowerCase().includes(search.toLowerCase())
+    );
+
+    const handleAssign = async (referee: RefereeOption) => {
+        if (currentReferees.length >= 3) {
+            setError("This table already has the maximum of 3 referees.");
+            return;
+        }
+        if (referee.assignedTableId && referee.assignedTableId !== tableId) {
+            if (pendingHref !== referee.href) {
+                setPendingHref(referee.href);
+                return;
+            }
+        }
+
+        setError(null);
+        setIsLoading(true);
+        try {
+            await service.assignRefereeToTable(referee.href, tableId);
+            setPendingHref(null);
+            router.refresh();
+            onClose();
+        } catch (e) {
+            setError(parseErrorMessage(e));
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleRemove = async (referee: RefereeOption) => {
+        setError(null);
+        setIsLoading(true);
+        try {
+            await service.removeRefereeFromTable(referee.href);
+            router.refresh();
+            onClose();
+        } catch (e) {
+            setError(parseErrorMessage(e));
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <div className="rounded-lg border bg-card p-6 shadow-sm space-y-4">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h3 className="text-lg font-medium">Assign Referee</h3>
+                    <p className="text-sm text-muted-foreground">Table: {tableId} — {currentReferees.length}/3 referees assigned</p>
+                </div>
+                <Button variant="outline" size="sm" onClick={onClose} disabled={isLoading}>
+                    <X className="h-4 w-4" />
+                </Button>
+            </div>
+
+            {error && (
+                <div className="flex items-center gap-3 border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm font-medium text-red-700">
+                    <AlertCircle className="h-5 w-5 text-red-600 shrink-0" />
+                    {error}
+                </div>
+            )}
+
+            <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search referees..."
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+
+            <div className="max-h-72 overflow-y-auto divide-y divide-border rounded-md border">
+                {filteredReferees.length === 0 && (
+                    <p className="px-4 py-6 text-center text-sm text-muted-foreground">No referees found.</p>
+                )}
+                {filteredReferees.map((referee) => {
+                    const isAssignedHere = currentRefereeHrefs.has(referee.href);
+                    const isAssignedElsewhere = !isAssignedHere && !!referee.assignedTableId;
+                    const isPending = pendingHref === referee.href;
+
+                    return (
+                        <div key={referee.href} className="flex items-center justify-between px-4 py-3 gap-3">
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium truncate">{referee.name}</p>
+                                <p className="text-xs text-muted-foreground truncate">{referee.emailAddress}</p>
+                                {isAssignedElsewhere && (
+                                    <p className="text-xs text-amber-600 font-medium">Assigned to {referee.assignedTableId}</p>
+                                )}
+                                {isPending && (
+                                    <p className="text-xs text-amber-700 font-semibold">Will be reassigned from {referee.assignedTableId}. Click again to confirm.</p>
+                                )}
+                            </div>
+                            <div className="shrink-0">
+                                {isAssignedHere ? (
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => handleRemove(referee)}
+                                        disabled={isLoading}
+                                    >
+                                        <UserCheck className="mr-1 h-3 w-3 text-green-600" />
+                                        Remove
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        size="sm"
+                                        variant={isPending ? "destructive" : "outline"}
+                                        onClick={() => handleAssign(referee)}
+                                        disabled={isLoading}
+                                    >
+                                        {isPending ? "Confirm reassign" : "Assign"}
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/app/competition-tables/competition-table-list.tsx
+++ b/src/app/competition-tables/competition-table-list.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2, UserPlus } from "lucide-react";
+import { Button, buttonVariants } from "@/app/components/button";
+import EmptyState from "@/app/components/empty-state";
+import { CompetitionTableService } from "@/api/competitionTableApi";
+import { clientAuthProvider } from "@/lib/authProvider";
+import { parseErrorMessage } from "@/types/errors";
+import CreateCompetitionTableDialog from "./create-competition-table-dialog";
+import AssignRefereeDialog, { RefereeOption } from "./assign-referee-dialog";
+
+interface CompetitionTableListProps {
+    tables: string[];
+    refereesByTable: Record<string, RefereeOption[]>;
+    allReferees: RefereeOption[];
+}
+
+export default function CompetitionTableList({ tables, refereesByTable, allReferees }: CompetitionTableListProps) {
+    const router = useRouter();
+    const [assigningTable, setAssigningTable] = useState<string | null>(null);
+    const [deletingTable, setDeletingTable] = useState<string | null>(null);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+
+    const handleDelete = async (tableId: string) => {
+        setDeleteError(null);
+        setDeletingTable(tableId);
+        try {
+            const service = new CompetitionTableService(clientAuthProvider);
+            await service.deleteTable(tableId);
+            router.refresh();
+        } catch (e) {
+            setDeleteError(parseErrorMessage(e));
+        } finally {
+            setDeletingTable(null);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-3">
+                <div className="page-eyebrow">Management</div>
+                <h2 className="section-title">Tables</h2>
+            </div>
+
+            <CreateCompetitionTableDialog />
+
+            {deleteError && (
+                <div className="rounded-md border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-700">
+                    {deleteError}
+                </div>
+            )}
+
+            {tables.length === 0 && (
+                <EmptyState
+                    title="No competition tables"
+                    description="Create the first table to get started."
+                />
+            )}
+
+            {assigningTable && (
+                <AssignRefereeDialog
+                    tableId={assigningTable}
+                    currentReferees={refereesByTable[assigningTable] ?? []}
+                    allReferees={allReferees}
+                    onClose={() => setAssigningTable(null)}
+                />
+            )}
+
+            {tables.length > 0 && (
+                <div className="rounded-lg border border-border overflow-hidden">
+                    <table className="w-full text-sm">
+                        <thead className="bg-muted/50">
+                            <tr>
+                                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Table</th>
+                                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Referees</th>
+                                <th className="px-4 py-3 text-right font-medium text-muted-foreground">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-border">
+                            {tables.map((tableId) => {
+                                const referees = refereesByTable[tableId] ?? [];
+                                return (
+                                    <tr key={tableId} className="bg-card hover:bg-muted/30 transition-colors">
+                                        <td className="px-4 py-3 font-medium">{tableId}</td>
+                                        <td className="px-4 py-3 text-muted-foreground">
+                                            {referees.length === 0 ? (
+                                                <span className="text-xs italic">No referees assigned</span>
+                                            ) : (
+                                                <ul className="space-y-0.5">
+                                                    {referees.map(r => (
+                                                        <li key={r.href} className="text-xs">{r.name}</li>
+                                                    ))}
+                                                </ul>
+                                            )}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <div className="flex items-center justify-end gap-2">
+                                                <button
+                                                    onClick={() => setAssigningTable(tableId)}
+                                                    className={buttonVariants({ variant: "outline", size: "sm" })}
+                                                    disabled={!!deletingTable}
+                                                >
+                                                    <UserPlus className="mr-1 h-3 w-3" />
+                                                    Referees
+                                                </button>
+                                                <Button
+                                                    variant="destructive"
+                                                    size="sm"
+                                                    onClick={() => handleDelete(tableId)}
+                                                    disabled={deletingTable === tableId}
+                                                >
+                                                    <Trash2 className="mr-1 h-3 w-3" />
+                                                    {deletingTable === tableId ? "Deleting..." : "Delete"}
+                                                </Button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/competition-tables/create-competition-table-dialog.tsx
+++ b/src/app/competition-tables/create-competition-table-dialog.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, AlertCircle } from "lucide-react";
+import { Button } from "@/app/components/button";
+import { Input } from "@/app/components/input";
+import { Label } from "@/app/components/label";
+import { CompetitionTableService } from "@/api/competitionTableApi";
+import { clientAuthProvider } from "@/lib/authProvider";
+import { parseErrorMessage } from "@/types/errors";
+
+export default function CreateCompetitionTableDialog() {
+    const router = useRouter();
+    const [isOpen, setIsOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [identifier, setIdentifier] = useState("");
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError(null);
+
+        if (!identifier.trim()) {
+            setError("Table identifier is required.");
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            const service = new CompetitionTableService(clientAuthProvider);
+            await service.createTable(identifier.trim());
+            setIdentifier("");
+            setIsOpen(false);
+            router.refresh();
+        } catch (e) {
+            setError(parseErrorMessage(e));
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    if (!isOpen) {
+        return (
+            <Button onClick={() => setIsOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Create table
+            </Button>
+        );
+    }
+
+    return (
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <div className="mb-4">
+                <h3 className="text-lg font-medium">Create Competition Table</h3>
+                <p className="text-sm text-muted-foreground">
+                    Enter a unique identifier for the new table (e.g. &quot;Table-A&quot;, &quot;Red Table&quot;).
+                </p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+                {error && (
+                    <div className="flex items-center gap-3 border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm font-medium text-red-700">
+                        <AlertCircle className="h-5 w-5 text-red-600 shrink-0" />
+                        {error}
+                    </div>
+                )}
+
+                <div className="space-y-2">
+                    <Label htmlFor="table-id">Table identifier</Label>
+                    <Input
+                        id="table-id"
+                        value={identifier}
+                        onChange={(e) => setIdentifier(e.target.value)}
+                        placeholder="e.g. Table-A"
+                        disabled={isLoading}
+                    />
+                </div>
+
+                <div className="flex gap-3 pt-2">
+                    <Button type="submit" disabled={isLoading}>
+                        {isLoading ? "Creating..." : "Create table"}
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => { setIsOpen(false); setError(null); }}
+                        disabled={isLoading}
+                    >
+                        Cancel
+                    </Button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/src/app/competition-tables/page.tsx
+++ b/src/app/competition-tables/page.tsx
@@ -1,0 +1,81 @@
+import { CompetitionTableService, getTableId, getRefereeAssignedTableId } from "@/api/competitionTableApi";
+import PageShell from "@/app/components/page-shell";
+import ErrorAlert from "@/app/components/error-alert";
+import { serverAuthProvider } from "@/lib/authProvider";
+import { UsersService } from "@/api/userApi";
+import { isAdmin } from "@/lib/authz";
+import { parseErrorMessage } from "@/types/errors";
+import { redirect } from "next/navigation";
+import { CompetitionTable } from "@/types/competitionTable";
+import { Referee } from "@/types/referee";
+import CompetitionTableList from "./competition-table-list";
+import { RefereeOption } from "./assign-referee-dialog";
+
+export const dynamic = "force-dynamic";
+
+function toRefereeOption(r: Referee): RefereeOption {
+    return {
+        href: r.link("self")?.href ?? "",
+        name: r.name ?? r.emailAddress ?? "Unknown",
+        emailAddress: r.emailAddress ?? "",
+        assignedTableId: getRefereeAssignedTableId(r),
+    };
+}
+
+export default async function CompetitionTablesPage() {
+    const auth = await serverAuthProvider.getAuth();
+    if (!auth) redirect("/login");
+
+    const userService = new UsersService(serverAuthProvider);
+    const tableService = new CompetitionTableService(serverAuthProvider);
+
+    let tables: CompetitionTable[] = [];
+    let allReferees: Referee[] = [];
+    let error: string | null = null;
+
+    try {
+        const currentUser = await userService.getCurrentUser();
+        if (!isAdmin(currentUser)) redirect("/");
+    } catch {
+        redirect("/login");
+    }
+
+    try {
+        [tables, allReferees] = await Promise.all([
+            tableService.getTables(),
+            tableService.getReferees(),
+        ]);
+    } catch (e) {
+        console.error("Failed to fetch competition tables data:", e);
+        error = parseErrorMessage(e);
+    }
+
+    const allRefereeOptions = allReferees.map(toRefereeOption);
+
+    const refereesByTable: Record<string, RefereeOption[]> = {};
+    for (const option of allRefereeOptions) {
+        if (option.assignedTableId) {
+            refereesByTable[option.assignedTableId] = [...(refereesByTable[option.assignedTableId] ?? []), option];
+        }
+    }
+
+    const tableIds = tables.map(getTableId);
+
+    return (
+        <PageShell
+            eyebrow="Administration"
+            title="Competition Tables"
+            description="Manage physical match tables and assign referees."
+        >
+            {error && <ErrorAlert message={error} />}
+
+            {!error && (
+                <CompetitionTableList
+                    tables={tableIds}
+                    refereesByTable={refereesByTable}
+                    allReferees={allRefereeOptions}
+                />
+            )}
+        </PageShell>
+    );
+}

--- a/src/app/competition-tables/page.tsx
+++ b/src/app/competition-tables/page.tsx
@@ -1,4 +1,4 @@
-import { CompetitionTableService, getTableId, getRefereeAssignedTableId } from "@/api/competitionTableApi";
+import { CompetitionTableService, getTableId } from "@/api/competitionTableApi";
 import PageShell from "@/app/components/page-shell";
 import ErrorAlert from "@/app/components/error-alert";
 import { serverAuthProvider } from "@/lib/authProvider";
@@ -13,12 +13,16 @@ import { RefereeOption } from "./assign-referee-dialog";
 
 export const dynamic = "force-dynamic";
 
-function toRefereeOption(r: Referee): RefereeOption {
+function refereeHref(r: Referee): string {
+    return r.link("self")?.href ?? "";
+}
+
+function toRefereeOption(r: Referee, assignedTableId: string | null): RefereeOption {
     return {
-        href: r.link("self")?.href ?? "",
+        href: refereeHref(r),
         name: r.name ?? r.emailAddress ?? "Unknown",
         emailAddress: r.emailAddress ?? "",
-        assignedTableId: getRefereeAssignedTableId(r),
+        assignedTableId,
     };
 }
 
@@ -50,16 +54,33 @@ export default async function CompetitionTablesPage() {
         error = parseErrorMessage(e);
     }
 
-    const allRefereeOptions = allReferees.map(toRefereeOption);
+    const tableIds = tables.map(getTableId);
+
+    // Fetch referees per table to build the correct assignment map
+    const tableRefereeResults = await Promise.allSettled(
+        tableIds.map(async (tableId) => {
+            const referees = await tableService.getRefereesForTable(tableId);
+            return { tableId, referees };
+        })
+    );
 
     const refereesByTable: Record<string, RefereeOption[]> = {};
-    for (const option of allRefereeOptions) {
-        if (option.assignedTableId) {
-            refereesByTable[option.assignedTableId] = [...(refereesByTable[option.assignedTableId] ?? []), option];
+    const assignedMap = new Map<string, string>(); // refereeHref → tableId
+
+    for (const result of tableRefereeResults) {
+        if (result.status === "fulfilled") {
+            const { tableId, referees } = result.value;
+            refereesByTable[tableId] = referees.map(r => toRefereeOption(r, tableId));
+            for (const r of referees) {
+                const href = refereeHref(r);
+                if (href) assignedMap.set(href, tableId);
+            }
         }
     }
 
-    const tableIds = tables.map(getTableId);
+    const allRefereeOptions = allReferees.map(r =>
+        toRefereeOption(r, assignedMap.get(refereeHref(r)) ?? null)
+    );
 
     return (
         <PageShell

--- a/src/app/components/navbar.tsx
+++ b/src/app/components/navbar.tsx
@@ -34,7 +34,8 @@ export default function Navbar() {
         { href: "/volunteers", label: "Volunteers" },
         { href: "/scientific-projects", label: "Scientific Projects" },
         { href: "/matches", label: "Matches" },
-        { href: "/administrators", label: "Administrators", roles: ["ROLE_ADMIN"] }
+        { href: "/administrators", label: "Administrators", roles: ["ROLE_ADMIN"] },
+        { href: "/competition-tables", label: "Tables", roles: ["ROLE_ADMIN"] }
     ];
 
 

--- a/src/app/components/navbar.tsx
+++ b/src/app/components/navbar.tsx
@@ -34,8 +34,7 @@ export default function Navbar() {
         { href: "/volunteers", label: "Volunteers" },
         { href: "/scientific-projects", label: "Scientific Projects" },
         { href: "/matches", label: "Matches" },
-        { href: "/administrators", label: "Administrators", roles: ["ROLE_ADMIN"] },
-        { href: "/competition-tables", label: "Tables", roles: ["ROLE_ADMIN"] }
+        { href: "/administrators", label: "Administrators", roles: ["ROLE_ADMIN"] }
     ];
 
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,11 @@ export default function Home() {
       href: "/project-rooms",
       title: "Project Rooms",
       description: "Judging rooms, panels and assigned projects.",
+    },
+    {
+      href: "/competition-tables",
+      title: "Competition Tables",
+      description: "Match tables and referee assignments.",
     }
   ];
 

--- a/src/types/competitionTable.ts
+++ b/src/types/competitionTable.ts
@@ -2,6 +2,7 @@ import { Resource } from "halfred";
 
 export interface CompetitionTableEntity {
     uri?: string;
+    id?: string;
 }
 
 export type CompetitionTable = CompetitionTableEntity & Resource;


### PR DESCRIPTION
Add protected /competition-tables admin page with full CRUD for competition tables and referee assignment. Referees can be assigned to a table (max 3), with conflict detection and confirmation when reassigning from another table.

Closes #241