### PR TITLE
feat(media): add HTML5 video player in lightbox for video/* media items

### DIFF
--- a/src/app/components/media-gallery.tsx
+++ b/src/app/components/media-gallery.tsx
@@ -107,6 +107,15 @@ function LightboxMedia({ item, index }: { readonly item: MediaItem; readonly ind
         // eslint-disable-next-line @next/next/no-img-element
         return <img src={item.url} alt={`Media ${index + 1}`} className="max-h-[60vh] max-w-full rounded-xl object-contain shadow-lg" />;
     }
+    if (isVideo(item.type) && item.url) {
+        return (
+            <video
+                src={item.url}
+                controls
+                className="max-h-[60vh] max-w-full rounded-xl shadow-lg"
+            />
+        );
+    }
     if (isVideo(item.type)) {
         return (
             <div className="flex h-56 w-full max-w-sm items-center justify-center rounded-xl bg-zinc-900">

--- a/src/app/components/media-gallery.tsx
+++ b/src/app/components/media-gallery.tsx
@@ -113,7 +113,9 @@ function LightboxMedia({ item, index }: { readonly item: MediaItem; readonly ind
                 src={item.url}
                 controls
                 className="max-h-[60vh] max-w-full rounded-xl shadow-lg"
-            />
+            >
+                <track kind="captions" />
+            </video>
         );
     }
     if (isVideo(item.type)) {


### PR DESCRIPTION
Replace the "Video — preview not available" placeholder in the media lightbox with a native HTML5 `<video>` player when a URL is available. Falls back to the existing placeholder when no URL is present. Image and YouTube previews remain unchanged.

Closes #281