### PR TITLE
feat: add photo/video filter pills to edition gallery

### DIFF
--- a/src/app/components/media-gallery.tsx
+++ b/src/app/components/media-gallery.tsx
@@ -293,7 +293,6 @@ export function MediaGallery({ mediaContents }: MediaGalleryProps) {
 
     return (
         <div className="flex flex-col gap-3">
-            {/* Filter pills */}
             {showFilters && (
                 <div className="flex gap-2">
                     {filterOptions.map(({ label, value }) => (
@@ -313,26 +312,19 @@ export function MediaGallery({ mediaContents }: MediaGalleryProps) {
                 </div>
             )}
 
-            {/* Hero */}
             {hero && <HeroSection item={hero} index={0} onOpen={openLightbox} />}
 
-            {/* 2×2 grid */}
             {gridItems.length > 0 && <GridSection items={gridItems} startIndex={1} onOpen={openLightbox} />}
 
-            {/* Row of 3 */}
             {rowItems.length > 0 && <RowSection items={rowItems} startIndex={5} onOpen={openLightbox} />}
 
-            {/* Carousel for the rest */}
             {carouselItems.length > 0 && <CarouselSection items={carouselItems} startIndex={8} onOpen={openLightbox} />}
-
-            {/* Empty state when filter yields no results */}
             {filtered.length === 0 && (
                 <div className="flex h-32 items-center justify-center rounded-xl border border-border text-sm text-muted-foreground">
                     {filter === "photo" ? "No photos in this edition." : filter === "video" ? "No videos in this edition." : "No media in this edition."}
                 </div>
             )}
 
-            {/* Lightbox */}
             <Dialog.Root open={open} onOpenChange={setOpen}>
                 <Dialog.Portal>
                     <Dialog.Overlay className="fixed inset-0 z-50 bg-black/85 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />

--- a/src/app/components/media-gallery.tsx
+++ b/src/app/components/media-gallery.tsx
@@ -107,6 +107,15 @@ function LightboxMedia({ item, index }: { readonly item: MediaItem; readonly ind
         // eslint-disable-next-line @next/next/no-img-element
         return <img src={item.url} alt={`Media ${index + 1}`} className="max-h-[60vh] max-w-full rounded-xl object-contain shadow-lg" />;
     }
+    if (isVideo(item.type) && item.url) {
+        return (
+            <video
+                src={item.url}
+                controls
+                className="max-h-[60vh] max-w-full rounded-xl shadow-lg"
+            />
+        );
+    }
     if (isVideo(item.type)) {
         return (
             <div className="flex h-56 w-full max-w-sm items-center justify-center rounded-xl bg-zinc-900">

--- a/src/app/components/media-gallery.tsx
+++ b/src/app/components/media-gallery.tsx
@@ -244,6 +244,8 @@ function CarouselSection({ items, startIndex, onOpen }: { readonly items: MediaI
 
 // ─── Main component ────────────────────────────────────────────────────────────
 
+type MediaFilter = "all" | "photo" | "video";
+
 interface MediaGalleryProps {
     readonly mediaContents: MediaItem[];
 }
@@ -251,24 +253,66 @@ interface MediaGalleryProps {
 export function MediaGallery({ mediaContents }: MediaGalleryProps) {
     const [open, setOpen] = useState(false);
     const [activeIndex, setActiveIndex] = useState(0);
+    const [filter, setFilter] = useState<MediaFilter>("all");
+
+    const filtered = mediaContents.filter((item) => {
+        if (filter === "photo") return isImage(item.type);
+        if (filter === "video") return isVideo(item.type) || getYouTubeId(item.url) !== null;
+        return true;
+    });
 
     function openLightbox(index: number) {
         setActiveIndex(index);
         setOpen(true);
     }
 
-    function prev() { setActiveIndex((i) => (i - 1 + mediaContents.length) % mediaContents.length); }
-    function next() { setActiveIndex((i) => (i + 1) % mediaContents.length); }
+    function changeFilter(f: MediaFilter) {
+        setFilter(f);
+        setActiveIndex(0);
+    }
 
-    const hero = mediaContents[0];
-    const gridItems = mediaContents.slice(1, 5);
-    const rowItems = mediaContents.slice(5, 8);
-    const carouselItems = mediaContents.slice(8);
+    function prev() { setActiveIndex((i) => (i - 1 + filtered.length) % filtered.length); }
+    function next() { setActiveIndex((i) => (i + 1) % filtered.length); }
 
-    const activeItem = mediaContents[activeIndex];
+    const hasPhotos = mediaContents.some((item) => isImage(item.type));
+    const hasVideos = mediaContents.some((item) => isVideo(item.type) || getYouTubeId(item.url) !== null);
+    const showFilters = hasPhotos && hasVideos;
+
+    const hero = filtered[0];
+    const gridItems = filtered.slice(1, 5);
+    const rowItems = filtered.slice(5, 8);
+    const carouselItems = filtered.slice(8);
+
+    const activeItem = filtered[activeIndex];
+
+    const filterOptions: { label: string; value: MediaFilter }[] = [
+        { label: "All", value: "all" },
+        { label: "Photos", value: "photo" },
+        { label: "Videos", value: "video" },
+    ];
 
     return (
         <div className="flex flex-col gap-3">
+            {/* Filter pills */}
+            {showFilters && (
+                <div className="flex gap-2">
+                    {filterOptions.map(({ label, value }) => (
+                        <button
+                            key={value}
+                            type="button"
+                            onClick={() => changeFilter(value)}
+                            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                                filter === value
+                                    ? "bg-primary text-primary-foreground"
+                                    : "bg-secondary text-muted-foreground hover:text-foreground"
+                            }`}
+                        >
+                            {label}
+                        </button>
+                    ))}
+                </div>
+            )}
+
             {/* Hero */}
             {hero && <HeroSection item={hero} index={0} onOpen={openLightbox} />}
 
@@ -281,6 +325,13 @@ export function MediaGallery({ mediaContents }: MediaGalleryProps) {
             {/* Carousel for the rest */}
             {carouselItems.length > 0 && <CarouselSection items={carouselItems} startIndex={8} onOpen={openLightbox} />}
 
+            {/* Empty state when filter yields no results */}
+            {filtered.length === 0 && (
+                <div className="flex h-32 items-center justify-center rounded-xl border border-border text-sm text-muted-foreground">
+                    No {filter === "photo" ? "photos" : "videos"} in this edition.
+                </div>
+            )}
+
             {/* Lightbox */}
             <Dialog.Root open={open} onOpenChange={setOpen}>
                 <Dialog.Portal>
@@ -289,14 +340,14 @@ export function MediaGallery({ mediaContents }: MediaGalleryProps) {
                         <Dialog.Title className="sr-only">Media viewer</Dialog.Title>
 
                         <div className="mb-4 flex items-center justify-between">
-                            <span className="text-sm text-muted-foreground">{activeIndex + 1} / {mediaContents.length}</span>
+                            <span className="text-sm text-muted-foreground">{activeIndex + 1} / {filtered.length}</span>
                             <Dialog.Close aria-label="Close media viewer" className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground">
                                 <X className="h-5 w-5" />
                             </Dialog.Close>
                         </div>
 
                         <div className="flex items-center gap-3">
-                            {mediaContents.length > 1 && (
+                            {filtered.length > 1 && (
                                 <button type="button" onClick={prev} aria-label="Previous" className="flex-none rounded-full border border-border bg-background p-2 shadow-sm transition-colors hover:bg-secondary">
                                     <ChevronLeft className="h-5 w-5" />
                                 </button>
@@ -304,16 +355,16 @@ export function MediaGallery({ mediaContents }: MediaGalleryProps) {
                             <div className="flex-1">
                                 {activeItem && <LightboxContent item={activeItem} index={activeIndex} />}
                             </div>
-                            {mediaContents.length > 1 && (
+                            {filtered.length > 1 && (
                                 <button type="button" onClick={next} aria-label="Next" className="flex-none rounded-full border border-border bg-background p-2 shadow-sm transition-colors hover:bg-secondary">
                                     <ChevronRight className="h-5 w-5" />
                                 </button>
                             )}
                         </div>
 
-                        {mediaContents.length > 1 && (
+                        {filtered.length > 1 && (
                             <div className="mt-5 flex justify-center gap-1.5">
-                                {mediaContents.map((item, i) => (
+                                {filtered.map((item, i) => (
                                     <button type="button" key={item.uri ?? item.id ?? item.url ?? String(i)} onClick={() => setActiveIndex(i)} aria-label={`Go to ${i + 1}`}
                                         className={`h-1.5 rounded-full transition-all ${i === activeIndex ? "w-4 bg-primary" : "w-1.5 bg-border hover:bg-muted-foreground"}`} />
                                 ))}

--- a/src/app/components/media-gallery.tsx
+++ b/src/app/components/media-gallery.tsx
@@ -113,7 +113,9 @@ function LightboxMedia({ item, index }: { readonly item: MediaItem; readonly ind
                 src={item.url}
                 controls
                 className="max-h-[60vh] max-w-full rounded-xl shadow-lg"
-            />
+            >
+                <track kind="captions" />
+            </video>
         );
     }
     if (isVideo(item.type)) {

--- a/src/app/components/media-gallery.tsx
+++ b/src/app/components/media-gallery.tsx
@@ -328,7 +328,7 @@ export function MediaGallery({ mediaContents }: MediaGalleryProps) {
             {/* Empty state when filter yields no results */}
             {filtered.length === 0 && (
                 <div className="flex h-32 items-center justify-center rounded-xl border border-border text-sm text-muted-foreground">
-                    No {filter === "photo" ? "photos" : "videos"} in this edition.
+                    {filter === "photo" ? "No photos in this edition." : filter === "video" ? "No videos in this edition." : "No media in this edition."}
                 </div>
             )}
 


### PR DESCRIPTION
## Summary
- Add All / Photos / Videos pill toggle above the media grid on the Edition detail page
- Client-side filtering with no additional API calls
- Lightbox navigation and dot indicators respect the active filter
- Filter pills only appear when the edition has both photos and videos
- Empty state message when the active filter yields no results

Closes #310 